### PR TITLE
remove Drycell dependency (shade Drycell)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,8 @@ val setupServer = tasks.create("setupServer") {
         // Copying plugins
         file("WorldGenTestServer/plugins").copyRecursively(file("$testDir/plugins"), true)
         // Copy Drycell lib
-        file("libs/Drycell.jar").copyTo(file("$testDir/plugins/Drycell.jar"), true)
+        //file("libs/Drycell.jar").copyTo(file("$testDir/plugins/Drycell.jar"), true)
+
         // Copying config
         val serverText = URL("https://raw.githubusercontent.com/PolyhedralDev/WorldGenTestServer/master/server.properties").readText()
         file("${testDir}/server.properties").writeText(serverText)

--- a/buildProj/build.gradle.kts
+++ b/buildProj/build.gradle.kts
@@ -21,7 +21,8 @@ dependencies {
 }
 
 tasks.shadowJar {
-    relocate("io.papermc.lib", "org.terraform.lib")
+    relocate("io.papermc.lib", "org.terraform.lib.paperlib")
+    relocate("org.drycell", "org.terraform.lib.drycell")
 }
 
 java {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 dependencies {
     testCompile("junit", "junit", "4.12")
     compileOnly(group = "org.spigotmc", name = "spigot", version = "1.16.4-R0.1-SNAPSHOT")
-    compileOnly(fileTree("../libs/"))
+    implementation(fileTree("../libs/"))
     compileOnly("org.jetbrains:annotations:20.1.0")
 }
 java {

--- a/common/src/main/resources/plugin.yml
+++ b/common/src/main/resources/plugin.yml
@@ -1,11 +1,10 @@
 name: TerraformGenerator
 author: Hex_27
 version: 3.1.2
-depend: [ Drycell ]
 api-version: 1.14
 description: World Generator
 main: org.terraform.main.TerraformGeneratorPlugin
-load: startup
+load: STARTUP
 commands:
   terraform:
     description: Main command


### PR DESCRIPTION
This PR removes the dependency on the DryCell plugin entirely, by shading it into TerraForm during build. 

I've seen a couple people complain about the additional lib, and there's no real reason to have it as a separate plugin when it can just be shaded in like this.

This does **NOT** remove any DryCell code from the plugin. All this PR changes is the build process.