### PR TITLE
Fix built Jar not working on Java 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,25 +1,26 @@
 import java.io.ByteArrayOutputStream
 import java.net.URL
 import java.nio.channels.Channels
-import java.nio.file.Files
-import java.nio.file.Paths
-import java.nio.file.StandardCopyOption
 
 plugins {
     java
 }
 
-dependencies {
-	implementation(files("libs/spigot-1.17.jar"))
-}
+subprojects {
+    apply<JavaPlugin>()
 
-repositories {
-    mavenCentral()
-}
+    group = "org.terraform"
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        maven("https://repo.codemc.io/repository/nms/")
+    }
+
+    java {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
 }
 
 val testDir = "target/server"

--- a/buildProj/build.gradle.kts
+++ b/buildProj/build.gradle.kts
@@ -1,17 +1,8 @@
 plugins {
-    java
     id("com.github.johnrengelman.shadow").version("6.1.0")
 }
 
-group = "org.terraform"
-
-repositories {
-    maven { url = uri("https://repo.codemc.io/repository/nms/") }
-    mavenCentral()
-}
-
 dependencies {
-    testImplementation("junit", "junit", "4.12")
     implementation(project(":common"))
     implementation(project(":implementation:v1_14_R1"))
     implementation(project(":implementation:v1_15_R1"))
@@ -23,9 +14,4 @@ dependencies {
 
 tasks.shadowJar {
     relocate("io.papermc.lib", "org.terraform.lib")
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,24 +1,6 @@
-plugins {
-    java
-}
-
 group = "org.terraform"
 
-repositories {
-    maven{ url = uri("https://repo.codemc.io/repository/nms/") }
-    mavenCentral()
-    flatDir {
-        dirs("../libs")
-    }
-}
-
 dependencies {
-    testImplementation("junit", "junit", "4.12")
     compileOnly(group = "org.spigotmc", name = "spigot", version = "1.16.4-R0.1-SNAPSHOT")
-    compileOnly(fileTree("../libs/"))
     compileOnly("org.jetbrains:annotations:20.1.0")
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
 }

--- a/implementation/v1_14_R1/build.gradle.kts
+++ b/implementation/v1_14_R1/build.gradle.kts
@@ -1,21 +1,4 @@
-plugins {
-    java
-}
-
-group = "org.terraform"
-
-repositories {
-    mavenCentral()
-    maven{ url = uri("https://repo.codemc.io/repository/nms/") }
-}
-
 dependencies {
     implementation(project(":common"))
-    testImplementation("junit", "junit", "4.12")
     compileOnly(group = "org.spigotmc", name = "spigot", version = "1.14.4-R0.1-SNAPSHOT")
-    compileOnly(fileTree("../../libs/"))
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
 }

--- a/implementation/v1_15_R1/build.gradle.kts
+++ b/implementation/v1_15_R1/build.gradle.kts
@@ -1,21 +1,4 @@
-plugins {
-    java
-}
-
-group = "org.terraform"
-
-repositories {
-    mavenCentral()
-    maven{ url = uri("https://repo.codemc.io/repository/nms/") }
-}
-
 dependencies {
     implementation(project(":common"))
-    testImplementation("junit", "junit", "4.12")
     compileOnly(group = "org.spigotmc", name = "spigot", version = "1.15.2-R0.1-SNAPSHOT")
-    compileOnly(fileTree("../../libs/"))
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
 }

--- a/implementation/v1_16_R1/build.gradle.kts
+++ b/implementation/v1_16_R1/build.gradle.kts
@@ -1,21 +1,6 @@
-plugins {
-    java
-}
-
 group = "org.terraform"
-
-repositories {
-    mavenCentral()
-    maven{ url = uri("https://repo.codemc.io/repository/nms/") }
-}
 
 dependencies {
     implementation(project(":common"))
-    testImplementation("junit", "junit", "4.12")
     compileOnly(group = "org.spigotmc", name = "spigot", version = "1.16.1-R0.1-SNAPSHOT")
-    compileOnly(fileTree("../../libs/"))
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
 }

--- a/implementation/v1_16_R2/build.gradle.kts
+++ b/implementation/v1_16_R2/build.gradle.kts
@@ -1,21 +1,4 @@
-plugins {
-    java
-}
-
-group = "org.terraform"
-
-repositories {
-    mavenCentral()
-    maven{ url = uri("https://repo.codemc.io/repository/nms/") }
-}
-
 dependencies {
     implementation(project(":common"))
-    testImplementation("junit", "junit", "4.12")
     compileOnly(group = "org.spigotmc", name = "spigot", version = "1.16.3-R0.1-SNAPSHOT")
-    compileOnly(fileTree("../../libs/"))
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
 }

--- a/implementation/v1_16_R3/build.gradle.kts
+++ b/implementation/v1_16_R3/build.gradle.kts
@@ -1,21 +1,4 @@
-plugins {
-    java
-}
-
-group = "org.terraform"
-
-repositories {
-    mavenCentral()
-    maven{ url = uri("https://repo.codemc.io/repository/nms/") }
-}
-
 dependencies {
     implementation(project(":common"))
-    testImplementation("junit", "junit", "4.12")
     compileOnly(group = "org.spigotmc", name = "spigot", version = "1.16.4-R0.1-SNAPSHOT")
-    compileOnly(fileTree("../../libs/"))
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
 }

--- a/implementation/v1_17_R1/build.gradle.kts
+++ b/implementation/v1_17_R1/build.gradle.kts
@@ -1,21 +1,4 @@
-plugins {
-    java
-}
-
-group = "org.terraform"
-
-repositories {
-    mavenCentral()
-    maven{ url = uri("https://repo.codemc.io/repository/nms/") }
-}
-
 dependencies {
     implementation(project(":common"))
-    testImplementation("junit", "junit", "4.12")
-    //compileOnly(group = "org.spigotmc", name = "spigot", version = "1.17-R0.1-SNAPSHOT")
-    compileOnly(fileTree("../../libs/"))
-}
-java {
-    sourceCompatibility = JavaVersion.VERSION_16
-    targetCompatibility = JavaVersion.VERSION_16
+    compileOnly("org.spigotmc", "spigot", "1.17-R0.1-SNAPSHOT")
 }


### PR DESCRIPTION
Also contains other various build improvements.
Maven local was temporarily added to the repo's until codemc fix their wrong nms publishing for 1.17.