### PR TITLE
Added name argument to schematic save

### DIFF
--- a/common/src/main/java/org/terraform/command/SchematicSaveCommand.java
+++ b/common/src/main/java/org/terraform/command/SchematicSaveCommand.java
@@ -6,19 +6,33 @@ import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.terraform.command.contants.InvalidArgumentException;
+import org.terraform.command.contants.SchematicArgument;
 import org.terraform.command.contants.TerraCommand;
+import org.terraform.command.contants.TerraCommandArgument;
 import org.terraform.main.TerraformGeneratorPlugin;
 import org.terraform.schematic.SchematicListener;
 import org.terraform.schematic.TerraRegion;
 import org.terraform.schematic.TerraSchematic;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Stack;
 
 public class SchematicSaveCommand extends TerraCommand {
 
     public SchematicSaveCommand(TerraformGeneratorPlugin plugin, String... aliases) {
         super(plugin, aliases);
+        this.parameters.add(new TerraCommandArgument<String>("schem-name", false) {
+            @Override
+            public String parse(CommandSender sender, String value) {
+                return value;
+            }
+
+            @Override
+            public String validate(CommandSender sender, String value) {
+                return value;
+            }
+        });
     }
 
     @Override
@@ -42,6 +56,12 @@ public class SchematicSaveCommand extends TerraCommand {
             throws InvalidArgumentException {
         Player p = (Player) sender;
         TerraRegion rg = SchematicListener.rgs.get(p.getUniqueId());
+
+        if(args.size() == 0) {
+            p.sendMessage(ChatColor.RED + "Specify a schematic name.");
+            return;
+        }
+
         if (rg == null || !rg.isComplete()) {
             p.sendMessage(ChatColor.RED + "Selection not ready.");
             return;
@@ -55,9 +75,12 @@ public class SchematicSaveCommand extends TerraCommand {
                 b.setType(Material.AIR);
             s.registerBlock(b);
         }
+
+        String name = args.pop();
+
         try {
-            s.export("new-schematic-" + System.currentTimeMillis() + ".terra");
-            p.sendMessage(ChatColor.GREEN + "Saved.");
+            s.export(name + ".terra");
+            p.sendMessage(ChatColor.GREEN + "Schematic saved with name " + name);
         } catch (IOException e) {
             p.sendMessage(ChatColor.RED + "A problem occurred.");
             e.printStackTrace();


### PR DESCRIPTION
- Added schem-name literal argument to SchematicSaveCommand to save schematics with custom names in dev mode.
- Added dedicated folder for saved schematics in Plugin#getDataFolder()/schematic