### PR TITLE
Remove all uses of toUpperCase() and toLowerCase() without a locale

### DIFF
--- a/common/src/main/java/org/terraform/biome/BiomeBank.java
+++ b/common/src/main/java/org/terraform/biome/BiomeBank.java
@@ -2,6 +2,7 @@ package org.terraform.biome;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Random;
 
 import org.terraform.biome.beach.*;
@@ -359,23 +360,23 @@ public enum BiomeBank {
 	//static BiomeBank singleBeach;
     public static void initSinglesConfig() {
     	try
-    	{ singleLand = BiomeBank.valueOf(TConfigOption.BIOME_SINGLE_TERRESTRIAL_TYPE.getString().toUpperCase()); }
+    	{ singleLand = BiomeBank.valueOf(TConfigOption.BIOME_SINGLE_TERRESTRIAL_TYPE.getString().toUpperCase(Locale.ENGLISH)); }
     	catch(IllegalArgumentException e)
     		{singleLand = null;}
     	try
-    	{ singleOcean = BiomeBank.valueOf(TConfigOption.BIOME_SINGLE_OCEAN_TYPE.getString().toUpperCase()); }
+    	{ singleOcean = BiomeBank.valueOf(TConfigOption.BIOME_SINGLE_OCEAN_TYPE.getString().toUpperCase(Locale.ENGLISH)); }
     	catch(IllegalArgumentException e)
     		{singleOcean = null;}
     	try
-    	{ singleDeepOcean = BiomeBank.valueOf(TConfigOption.BIOME_SINGLE_DEEPOCEAN_TYPE.getString().toUpperCase()); }
+    	{ singleDeepOcean = BiomeBank.valueOf(TConfigOption.BIOME_SINGLE_DEEPOCEAN_TYPE.getString().toUpperCase(Locale.ENGLISH)); }
     	catch(IllegalArgumentException e)
     		{singleDeepOcean = null;}
     	try
-    	{ singleMountain = BiomeBank.valueOf(TConfigOption.BIOME_SINGLE_MOUNTAIN_TYPE.getString().toUpperCase()); }
+    	{ singleMountain = BiomeBank.valueOf(TConfigOption.BIOME_SINGLE_MOUNTAIN_TYPE.getString().toUpperCase(Locale.ENGLISH)); }
     	catch(IllegalArgumentException e)
     		{singleMountain = null;}
     	try
-    	{ singleHighMountain = BiomeBank.valueOf(TConfigOption.BIOME_SINGLE_HIGHMOUNTAIN_TYPE.getString().toUpperCase()); }
+    	{ singleHighMountain = BiomeBank.valueOf(TConfigOption.BIOME_SINGLE_HIGHMOUNTAIN_TYPE.getString().toUpperCase(Locale.ENGLISH)); }
     	catch(IllegalArgumentException e)
     		{singleHighMountain = null;}
     }

--- a/common/src/main/java/org/terraform/biome/custombiomes/CustomBiomeType.java
+++ b/common/src/main/java/org/terraform/biome/custombiomes/CustomBiomeType.java
@@ -2,6 +2,8 @@ package org.terraform.biome.custombiomes;
 
 import org.terraform.utils.version.Version;
 
+import java.util.Locale;
+
 public enum CustomBiomeType {
     NONE,
     MUDDY_BOG("b8ad49","9c8046","b8ad49","d9cd62","ad8445","ad8445", 0.8f, false),
@@ -21,7 +23,7 @@ public enum CustomBiomeType {
     private boolean isCold = false;
 
     private CustomBiomeType() {
-        this.key = "terraformgenerator:" + this.toString().toLowerCase();
+        this.key = "terraformgenerator:" + this.toString().toLowerCase(Locale.ENGLISH);
         this.fogColor = "";
         this.waterColor = "";
         this.waterFogColor = "";
@@ -33,7 +35,7 @@ public enum CustomBiomeType {
     CustomBiomeType(String fogColor, String waterColor, String waterFogColor,
                     String skyColor, String foliageColor, String grassColor, float rainFall,
                     boolean isCold) {
-        this.key = "terraformgenerator:" + this.toString().toLowerCase();
+        this.key = "terraformgenerator:" + this.toString().toLowerCase(Locale.ENGLISH);
         this.fogColor = fogColor;
         this.waterColor = waterColor;
         this.waterFogColor = waterFogColor;

--- a/common/src/main/java/org/terraform/biome/flat/JungleHandler.java
+++ b/common/src/main/java/org/terraform/biome/flat/JungleHandler.java
@@ -24,6 +24,7 @@ import org.terraform.utils.noise.NoiseCacheHandler;
 import org.terraform.utils.noise.FastNoise.NoiseType;
 import org.terraform.utils.noise.NoiseCacheHandler.NoiseCacheEntry;
 
+import java.util.Locale;
 import java.util.Random;
 
 public class JungleHandler extends BiomeHandler {
@@ -232,7 +233,7 @@ public class JungleHandler extends BiomeHandler {
 	                            "cobblestone",
 	                            GenUtils.randMaterial(new Random(), 
 	                            		Material.COBBLESTONE, Material.ANDESITE, Material.STONE, Material.MOSSY_COBBLESTONE)
-	                                    .toString().toLowerCase()
+	                                    .toString().toLowerCase(Locale.ENGLISH)
 	                    )
 	            );
 	            super.applyData(block, data);

--- a/common/src/main/java/org/terraform/command/LocateBiomeCommand.java
+++ b/common/src/main/java/org/terraform/command/LocateBiomeCommand.java
@@ -17,6 +17,7 @@ import org.terraform.utils.GenUtils;
 import org.terraform.utils.Vector2f;
 
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Stack;
 import java.util.UUID;
 
@@ -94,7 +95,7 @@ public class LocateBiomeCommand extends TerraCommand {
         @Override
         public BiomeBank parse(CommandSender sender, String value) {
 
-            return BiomeBank.valueOf(value.toUpperCase());
+            return BiomeBank.valueOf(value.toUpperCase(Locale.ENGLISH));
         }
 
         @Override
@@ -113,7 +114,7 @@ public class LocateBiomeCommand extends TerraCommand {
             ArrayList<String> values = new ArrayList<>();
 
             for (BiomeBank bank : BiomeBank.values()) {
-            	if(bank.name().startsWith(args[1].toUpperCase()))
+            	if(bank.name().startsWith(args[1].toUpperCase(Locale.ENGLISH)))
             		values.add(bank.name());
             }
 

--- a/common/src/main/java/org/terraform/command/LocateCommand.java
+++ b/common/src/main/java/org/terraform/command/LocateCommand.java
@@ -23,6 +23,7 @@ import org.terraform.structure.StructurePopulator;
 import org.terraform.structure.StructureRegistry;
 import org.terraform.structure.stronghold.StrongholdPopulator;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Stack;
 import java.util.UUID;
 
@@ -202,7 +203,7 @@ public class LocateCommand extends TerraCommand implements Listener {
             ArrayList<String> values = new ArrayList<>();
 
             for (StructurePopulator spop : StructureRegistry.getAllPopulators()) {
-            	if(spop.getClass().getSimpleName().toUpperCase().startsWith(args[1].toUpperCase()))
+            	if(spop.getClass().getSimpleName().toUpperCase(Locale.ENGLISH).startsWith(args[1].toUpperCase(Locale.ENGLISH)))
             		values.add(spop.getClass().getSimpleName());
             }
 

--- a/common/src/main/java/org/terraform/command/SeekCommand.java
+++ b/common/src/main/java/org/terraform/command/SeekCommand.java
@@ -22,6 +22,7 @@ import org.terraform.structure.StructureRegistry;
 import org.terraform.structure.stronghold.StrongholdPopulator;
 
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Stack;
 
@@ -174,7 +175,7 @@ public class SeekCommand extends TerraCommand implements Listener {
             ArrayList<String> values = new ArrayList<>();
 
             for (StructurePopulator spop : StructureRegistry.getAllPopulators()) {
-            	if(spop.getClass().getSimpleName().toUpperCase().startsWith(args[1].toUpperCase()))
+            	if(spop.getClass().getSimpleName().toUpperCase(Locale.ENGLISH).startsWith(args[1].toUpperCase(Locale.ENGLISH)))
             		values.add(spop.getClass().getSimpleName());
             }
 

--- a/common/src/main/java/org/terraform/command/contants/FractalTreeTypeArgument.java
+++ b/common/src/main/java/org/terraform/command/contants/FractalTreeTypeArgument.java
@@ -1,6 +1,7 @@
 package org.terraform.command.contants;
 
 import java.util.ArrayList;
+import java.util.Locale;
 
 import org.bukkit.command.CommandSender;
 import org.terraform.tree.FractalTypes;
@@ -16,7 +17,7 @@ public class FractalTreeTypeArgument extends TerraCommandArgument<FractalTypes.T
     @Override
     public FractalTypes.Tree parse(CommandSender sender, String value) {
 
-        return FractalTypes.Tree.valueOf(value.toUpperCase());
+        return FractalTypes.Tree.valueOf(value.toUpperCase(Locale.ENGLISH));
     }
 
     @Override
@@ -35,12 +36,12 @@ public class FractalTreeTypeArgument extends TerraCommandArgument<FractalTypes.T
         ArrayList<String> values = new ArrayList<>();
 
 //        for (StructurePopulator spop : StructureRegistry.getAllPopulators()) {
-//        	if(spop.getClass().getSimpleName().toUpperCase().startsWith(args[1].toUpperCase()))
+//        	if(spop.getClass().getSimpleName().toUpperCase(Locale.ENGLISH).startsWith(args[1].toUpperCase(Locale.ENGLISH)))
 //        		values.add(spop.getClass().getSimpleName());
 //        }
         
         for(Tree type: FractalTypes.Tree.values()) {
-        	if(type.toString().startsWith(args[1].toUpperCase()))
+        	if(type.toString().startsWith(args[1].toUpperCase(Locale.ENGLISH)))
         		values.add(type.toString());
         }
         

--- a/common/src/main/java/org/terraform/command/contants/MushroomTypeArgument.java
+++ b/common/src/main/java/org/terraform/command/contants/MushroomTypeArgument.java
@@ -1,6 +1,7 @@
 package org.terraform.command.contants;
 
 import java.util.ArrayList;
+import java.util.Locale;
 
 import org.bukkit.command.CommandSender;
 import org.terraform.tree.FractalTypes;
@@ -16,7 +17,7 @@ public class MushroomTypeArgument extends TerraCommandArgument<FractalTypes.Mush
     @Override
     public FractalTypes.Mushroom parse(CommandSender sender, String value) {
 
-        return FractalTypes.Mushroom.valueOf(value.toUpperCase());
+        return FractalTypes.Mushroom.valueOf(value.toUpperCase(Locale.ENGLISH));
     }
 
     @Override
@@ -36,12 +37,12 @@ public class MushroomTypeArgument extends TerraCommandArgument<FractalTypes.Mush
         ArrayList<String> values = new ArrayList<>();
 
 //        for (StructurePopulator spop : StructureRegistry.getAllPopulators()) {
-//        	if(spop.getClass().getSimpleName().toUpperCase().startsWith(args[1].toUpperCase()))
+//        	if(spop.getClass().getSimpleName().toUpperCase(Locale.ENGLISH).startsWith(args[1].toUpperCase(Locale.ENGLISH)))
 //        		values.add(spop.getClass().getSimpleName());
 //        }
         
         for(Mushroom type: FractalTypes.Mushroom.values()) {
-        	if(type.toString().startsWith(args[1].toUpperCase()))
+        	if(type.toString().startsWith(args[1].toUpperCase(Locale.ENGLISH)))
         		values.add(type.toString());
         }
         

--- a/common/src/main/java/org/terraform/command/contants/TerraCommand.java
+++ b/common/src/main/java/org/terraform/command/contants/TerraCommand.java
@@ -2,6 +2,7 @@ package org.terraform.command.contants;
 
 
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Stack;
 
 import org.bukkit.command.CommandSender;
@@ -70,7 +71,7 @@ public abstract class TerraCommand {
 	}
 	
 	public boolean matchCommand(String command){
-		command = command.toLowerCase();
+		command = command.toLowerCase(Locale.ENGLISH);
 		return aliases.contains(command);
 	}
 

--- a/common/src/main/java/org/terraform/main/LangOpt.java
+++ b/common/src/main/java/org/terraform/main/LangOpt.java
@@ -2,6 +2,8 @@ package org.terraform.main;
 
 import org.bukkit.command.CommandSender;
 
+import java.util.Locale;
+
 public enum LangOpt {
     COMMAND_LOCATE_NOVANILLA("&c&lFor terraformgenerator worlds, use &e&l/terra locate &c&linstead!"),
     COMMAND_LOCATE_STRUCTURE_NOT_ENABLED("&cThe specified structure was not enabled!"),
@@ -19,7 +21,7 @@ public enum LangOpt {
 
     LangOpt(String lang) {
         this.value = lang;
-        this.path = this.toString().toLowerCase().replace('_', '.');
+        this.path = this.toString().toLowerCase(Locale.ENGLISH).replace('_', '.');
     }
 
     LangOpt(String path, String lang) {

--- a/common/src/main/java/org/terraform/main/TerraformCommandManager.java
+++ b/common/src/main/java/org/terraform/main/TerraformCommandManager.java
@@ -16,6 +16,7 @@ import org.terraform.main.config.TConfigOption;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Stack;
 
 public class TerraformCommandManager implements TabExecutor {
@@ -137,7 +138,7 @@ public class TerraformCommandManager implements TabExecutor {
 			return false;
 		}
 		for(TerraCommand command:commands){
-			if(command.matchCommand(args[0].toLowerCase())){
+			if(command.matchCommand(args[0].toLowerCase(Locale.ENGLISH))){
 				Stack<String> stack = new Stack<String>();
 				//Push arguments from back to front, except the 1st arg
 				for(int i = args.length -1; i>=1; i--){
@@ -182,7 +183,7 @@ public class TerraformCommandManager implements TabExecutor {
             for (TerraCommand terraCommand : commands) {
                 if (terraCommand.hasPermission(commandSender))
                 	for(String a:terraCommand.aliases) {
-                		if(a.startsWith(args[0].toLowerCase())) {
+                		if(a.startsWith(args[0].toLowerCase(Locale.ENGLISH))) {
                 			options.add(terraCommand.aliases.get(0));
                 			break;
                 		}
@@ -190,7 +191,7 @@ public class TerraformCommandManager implements TabExecutor {
             }
         }else {
             for (TerraCommand terraCommand : commands) {
-                if (terraCommand.matchCommand(args[0].toLowerCase())) {
+                if (terraCommand.matchCommand(args[0].toLowerCase(Locale.ENGLISH))) {
                     for (TerraCommandArgument<?> arg : terraCommand.parameters) {
                         options.addAll(arg.getTabOptions(args));
                     }

--- a/common/src/main/java/org/terraform/structure/monument/MonumentDesign.java
+++ b/common/src/main/java/org/terraform/structure/monument/MonumentDesign.java
@@ -13,6 +13,7 @@ import org.terraform.schematic.TerraSchematic;
 import org.terraform.utils.BlockUtils;
 import org.terraform.utils.GenUtils;
 
+import java.util.Locale;
 import java.util.Random;
 
 public enum MonumentDesign {
@@ -65,7 +66,7 @@ public enum MonumentDesign {
             z++;
             y++;
             //World w = ((PopulatorDataPostGen) data).getWorld();
-            TerraSchematic schema = TerraSchematic.load(this.toString().toLowerCase() + "-largelight", new SimpleBlock(data,x,y,z));
+            TerraSchematic schema = TerraSchematic.load(this.toString().toLowerCase(Locale.ENGLISH) + "-largelight", new SimpleBlock(data,x,y,z));
             schema.parser = new MonumentSchematicParser();
             schema.setFace(BlockFace.NORTH);
             schema.apply();

--- a/common/src/main/java/org/terraform/structure/pillager/mansion/secondfloor/MansionSecondFloorLoungePopulator.java
+++ b/common/src/main/java/org/terraform/structure/pillager/mansion/secondfloor/MansionSecondFloorLoungePopulator.java
@@ -2,6 +2,7 @@ package org.terraform.structure.pillager.mansion.secondfloor;
 
 import java.io.FileNotFoundException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Random;
 
 import org.bukkit.Bukkit;
@@ -85,7 +86,7 @@ public class MansionSecondFloorLoungePopulator extends MansionRoomPopulator {
 	                    data.getAsString().replaceAll(
 	                            "black_glazed_terracotta",
 	                            terracottaType
-	                                    .toString().toLowerCase()
+	                                    .toString().toLowerCase(Locale.ENGLISH)
 	                    )
 	            );
 	            super.applyData(block, data);

--- a/common/src/main/java/org/terraform/structure/pillager/outpost/OutpostSchematicParser.java
+++ b/common/src/main/java/org/terraform/structure/pillager/outpost/OutpostSchematicParser.java
@@ -16,6 +16,7 @@ import org.terraform.utils.GenUtils;
 import org.terraform.utils.WoodUtils;
 import org.terraform.utils.WoodUtils.WoodType;
 
+import java.util.Locale;
 import java.util.Random;
 
 public class OutpostSchematicParser extends SchematicParser {
@@ -49,7 +50,7 @@ public class OutpostSchematicParser extends SchematicParser {
                     data.getAsString().replaceAll(
                             "cobblestone",
                             GenUtils.randMaterial(rand, toReplace)
-                                    .toString().toLowerCase()
+                                    .toString().toLowerCase(Locale.ENGLISH)
                     )
             );
         	
@@ -57,10 +58,10 @@ public class OutpostSchematicParser extends SchematicParser {
         } else if (data.getMaterial().toString().contains("OAK")) {
             data = Bukkit.createBlockData(
                     data.getAsString().replaceAll(
-                            data.getMaterial().toString().toLowerCase(),
+                            data.getMaterial().toString().toLowerCase(Locale.ENGLISH),
                             WoodUtils.getWoodForBiome(biome,
-                                    WoodType.parse(data.getMaterial())).toString().toLowerCase()
-                            ).toString().toLowerCase());
+                                    WoodType.parse(data.getMaterial())).toString().toLowerCase(Locale.ENGLISH)
+                            ).toString().toLowerCase(Locale.ENGLISH));
             super.applyData(block, data);
         } else if (data.getMaterial() == Material.CHEST) {
             if (GenUtils.chance(rand, 1, 5)) {

--- a/common/src/main/java/org/terraform/structure/village/plains/PlainsVillageFountainPopulator.java
+++ b/common/src/main/java/org/terraform/structure/village/plains/PlainsVillageFountainPopulator.java
@@ -16,6 +16,7 @@ import org.terraform.utils.BlockUtils;
 import org.terraform.utils.GenUtils;
 
 import java.io.FileNotFoundException;
+import java.util.Locale;
 import java.util.Random;
 
 public class PlainsVillageFountainPopulator extends RoomPopulatorAbstract {
@@ -99,7 +100,7 @@ public class PlainsVillageFountainPopulator extends RoomPopulatorAbstract {
                         data.getAsString().replaceAll(
                                 "cobblestone",
                                 GenUtils.randMaterial(rand, Material.COBBLESTONE, Material.COBBLESTONE, Material.COBBLESTONE, Material.MOSSY_COBBLESTONE)
-                                        .toString().toLowerCase()
+                                        .toString().toLowerCase(Locale.ENGLISH)
                         )
                 );
                 super.applyData(block, data);

--- a/common/src/main/java/org/terraform/structure/village/plains/PlainsVillagePopulator.java
+++ b/common/src/main/java/org/terraform/structure/village/plains/PlainsVillagePopulator.java
@@ -15,6 +15,7 @@ import org.terraform.utils.WoodUtils;
 import org.terraform.utils.WoodUtils.WoodType;
 import org.terraform.utils.GenUtils;
 
+import java.util.Locale;
 import java.util.Random;
 
 public class PlainsVillagePopulator extends VillagePopulator {
@@ -119,7 +120,7 @@ public class PlainsVillagePopulator extends VillagePopulator {
         woodPressurePlate = WoodUtils.getWoodForBiome(biome, WoodType.PRESSURE_PLATE);
         woodDoor = WoodUtils.getWoodForBiome(biome, WoodType.DOOR);
         woodLeaves = WoodUtils.getWoodForBiome(biome, WoodType.LEAVES);
-        wood = woodLeaves.toString().toLowerCase().replace("leaves","");
+        wood = woodLeaves.toString().toLowerCase(Locale.ENGLISH).replace("leaves","");
         
         //Re-get x and z because they change after ensureFarmHouseEntrance.
         //13 because that's the width of the townhall.

--- a/common/src/main/java/org/terraform/structure/village/plains/PlainsVillageWellPopulator.java
+++ b/common/src/main/java/org/terraform/structure/village/plains/PlainsVillageWellPopulator.java
@@ -18,6 +18,7 @@ import org.terraform.utils.GenUtils;
 import org.terraform.utils.version.Version;
 
 import java.io.FileNotFoundException;
+import java.util.Locale;
 import java.util.Random;
 
 public class PlainsVillageWellPopulator extends PlainsVillageAbstractRoomPopulator {
@@ -144,7 +145,7 @@ public class PlainsVillageWellPopulator extends PlainsVillageAbstractRoomPopulat
                         data.getAsString().replaceAll(
                                 "cobblestone",
                                 GenUtils.randMaterial(rand, Material.COBBLESTONE, Material.COBBLESTONE, Material.COBBLESTONE, Material.MOSSY_COBBLESTONE)
-                                        .toString().toLowerCase()
+                                        .toString().toLowerCase(Locale.ENGLISH)
                         )
                 );
                 super.applyData(block, data);

--- a/common/src/main/java/org/terraform/structure/villagehouse/animalfarm/AnimalFarmSchematicParser.java
+++ b/common/src/main/java/org/terraform/structure/villagehouse/animalfarm/AnimalFarmSchematicParser.java
@@ -12,6 +12,7 @@ import org.terraform.utils.GenUtils;
 import org.terraform.utils.WoodUtils;
 import org.terraform.utils.WoodUtils.WoodType;
 
+import java.util.Locale;
 import java.util.Random;
 
 public class AnimalFarmSchematicParser extends SchematicParser {
@@ -38,7 +39,7 @@ public class AnimalFarmSchematicParser extends SchematicParser {
                     data.getAsString().replaceAll(
                             "cobblestone",
                             GenUtils.randMaterial(rand, Material.COBBLESTONE, Material.COBBLESTONE, Material.COBBLESTONE, Material.MOSSY_COBBLESTONE)
-                                    .toString().toLowerCase()
+                                    .toString().toLowerCase(Locale.ENGLISH)
                     )
             );
             super.applyData(block, data);
@@ -56,10 +57,10 @@ public class AnimalFarmSchematicParser extends SchematicParser {
         } else if (data.getMaterial().toString().contains("OAK")) {
             data = Bukkit.createBlockData(
                     data.getAsString().replaceAll(
-                            data.getMaterial().toString().toLowerCase(),
+                            data.getMaterial().toString().toLowerCase(Locale.ENGLISH),
                             WoodUtils.getWoodForBiome(biome,
-                                    WoodType.parse(data.getMaterial())).toString().toLowerCase()
-                            ).toString().toLowerCase());
+                                    WoodType.parse(data.getMaterial())).toString().toLowerCase(Locale.ENGLISH)
+                            ).toString().toLowerCase(Locale.ENGLISH));
             super.applyData(block, data);
             return;
         } else if (data.getMaterial() == Material.CHEST) {

--- a/common/src/main/java/org/terraform/structure/villagehouse/farmhouse/FarmhouseSchematicParser.java
+++ b/common/src/main/java/org/terraform/structure/villagehouse/farmhouse/FarmhouseSchematicParser.java
@@ -12,6 +12,7 @@ import org.terraform.utils.GenUtils;
 import org.terraform.utils.WoodUtils;
 import org.terraform.utils.WoodUtils.WoodType;
 
+import java.util.Locale;
 import java.util.Random;
 
 public class FarmhouseSchematicParser extends SchematicParser {
@@ -34,17 +35,17 @@ public class FarmhouseSchematicParser extends SchematicParser {
                     data.getAsString().replaceAll(
                             "cobblestone",
                             GenUtils.randMaterial(rand, Material.COBBLESTONE, Material.COBBLESTONE, Material.COBBLESTONE, Material.MOSSY_COBBLESTONE)
-                                    .toString().toLowerCase()
+                                    .toString().toLowerCase(Locale.ENGLISH)
                     )
             );
             super.applyData(block, data);
         } else if (data.getMaterial().toString().contains("OAK")) {
             data = Bukkit.createBlockData(
                     data.getAsString().replaceAll(
-                            data.getMaterial().toString().toLowerCase(),
+                            data.getMaterial().toString().toLowerCase(Locale.ENGLISH),
                             WoodUtils.getWoodForBiome(biome,
-                                    WoodType.parse(data.getMaterial())).toString().toLowerCase()
-                            ).toString().toLowerCase());
+                                    WoodType.parse(data.getMaterial())).toString().toLowerCase(Locale.ENGLISH)
+                            ).toString().toLowerCase(Locale.ENGLISH));
             super.applyData(block, data);
         } else if (data.getMaterial() == Material.CHEST) {
             if (GenUtils.chance(rand, 1, 5)) {

--- a/common/src/main/java/org/terraform/structure/villagehouse/mountainhouse/MountainhouseSchematicParser.java
+++ b/common/src/main/java/org/terraform/structure/villagehouse/mountainhouse/MountainhouseSchematicParser.java
@@ -10,6 +10,7 @@ import org.terraform.data.SimpleBlock;
 import org.terraform.schematic.SchematicParser;
 import org.terraform.utils.GenUtils;
 
+import java.util.Locale;
 import java.util.Random;
 
 public class MountainhouseSchematicParser extends SchematicParser {
@@ -32,7 +33,7 @@ public class MountainhouseSchematicParser extends SchematicParser {
                     data.getAsString().replaceAll(
                             "cobblestone",
                             GenUtils.randMaterial(rand, Material.COBBLESTONE, Material.ANDESITE, Material.STONE_BRICKS, Material.CRACKED_STONE_BRICKS, Material.COBBLESTONE, Material.ANDESITE)
-                                    .toString().toLowerCase()
+                                    .toString().toLowerCase(Locale.ENGLISH)
                     )
             );
             super.applyData(block, data);
@@ -42,7 +43,7 @@ public class MountainhouseSchematicParser extends SchematicParser {
                     data.getAsString().replaceAll(
                             "bricks",
                             GenUtils.randMaterial(rand, Material.BRICKS, Material.GRANITE, Material.POLISHED_GRANITE)
-                                    .toString().toLowerCase()
+                                    .toString().toLowerCase(Locale.ENGLISH)
                     )
             );
             super.applyData(block, data);
@@ -52,7 +53,7 @@ public class MountainhouseSchematicParser extends SchematicParser {
                     data.getAsString().replaceAll(
                             "white_concrete",
                             GenUtils.randMaterial(rand, Material.WHITE_CONCRETE, Material.WHITE_CONCRETE, Material.WHITE_WOOL, Material.DIORITE, Material.DIORITE)
-                                    .toString().toLowerCase()
+                                    .toString().toLowerCase(Locale.ENGLISH)
                     )
             );
             super.applyData(block, data);
@@ -61,10 +62,10 @@ public class MountainhouseSchematicParser extends SchematicParser {
 //        else if (data.getMaterial().toString().contains("SPRUCE")) {
 //            data = Bukkit.createBlockData(
 //                    data.getAsString().replaceAll(
-//                            data.getMaterial().toString().toLowerCase(),
+//                            data.getMaterial().toString().toLowerCase(Locale.ENGLISH),
 //                            WoodUtils.getWoodForBiome(biome,
-//                                    WoodType.parse(data.getMaterial())).toString().toLowerCase()
-//                            ).toString().toLowerCase());
+//                                    WoodType.parse(data.getMaterial())).toString().toLowerCase(Locale.ENGLISH)
+//                            ).toString().toLowerCase(Locale.ENGLISH));
 //            super.applyData(block, data);
 //        } 
         else if (data.getMaterial() == Material.CHEST) {

--- a/common/src/main/java/org/terraform/utils/version/OneTwentyBlockHandler.java
+++ b/common/src/main/java/org/terraform/utils/version/OneTwentyBlockHandler.java
@@ -6,6 +6,7 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.EntityType;
 import org.terraform.utils.BlockUtils;
 
+import java.util.Locale;
 import java.util.Random;
 
 public class OneTwentyBlockHandler {
@@ -30,7 +31,7 @@ public class OneTwentyBlockHandler {
 
     public static BlockData getPinkPetalData(int count)
     {
-        return Bukkit.createBlockData("pink_petals[flower_amount=" + count + ",facing=" + BlockUtils.getDirectBlockFace(new Random()).toString().toLowerCase() +  "]");
+        return Bukkit.createBlockData("pink_petals[flower_amount=" + count + ",facing=" + BlockUtils.getDirectBlockFace(new Random()).toString().toLowerCase(Locale.ENGLISH) +  "]");
     }
 
     private static EntityType getCamel(){

--- a/implementation/v1_18_R2/src/main/java/org/terraform/v1_18_R2/CustomBiomeHandler.java
+++ b/implementation/v1_18_R2/src/main/java/org/terraform/v1_18_R2/CustomBiomeHandler.java
@@ -2,6 +2,8 @@ package org.terraform.v1_18_R2;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.Locale;
+
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_18_R2.CraftServer;
 import org.terraform.biome.custombiomes.CustomBiomeType;
@@ -59,7 +61,7 @@ public class CustomBiomeHandler {
 						registrywritable,
 						forestbiome
 						);
-				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase());
+				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase(Locale.ENGLISH));
 			} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
 				TerraformGeneratorPlugin.logger.error("Failed to register custom biome: " + type.getKey());
 				e.printStackTrace();
@@ -84,7 +86,7 @@ public class CustomBiomeHandler {
 	
 	private static void registerCustomBiomeBase(CustomBiomeType biomeType, DedicatedServer dedicatedserver, IRegistryWritable<BiomeBase> registrywritable, BiomeBase forestbiome) throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
 
-		ResourceKey<BiomeBase> newKey = ResourceKey.a(IRegistry.aP, new MinecraftKey("terraformgenerator", biomeType.toString().toLowerCase()));
+		ResourceKey<BiomeBase> newKey = ResourceKey.a(IRegistry.aP, new MinecraftKey("terraformgenerator", biomeType.toString().toLowerCase(Locale.ENGLISH)));
 
 		//BiomeBase.a is BiomeBuilder
 		BiomeBase.a newBiomeBuilder = new BiomeBase.a();

--- a/implementation/v1_18_R2/src/main/java/org/terraform/v1_18_R2/PopulatorDataICA.java
+++ b/implementation/v1_18_R2/src/main/java/org/terraform/v1_18_R2/PopulatorDataICA.java
@@ -127,7 +127,7 @@ public class PopulatorDataICA extends PopulatorDataICABiomeWriterAbstract {
     public Biome getBiome(int rawX, int rawZ) {
     	return parent.getBiome(rawX, rawZ);
         //return tw.getBiomeBank(rawX, rawZ).getHandler().getBiome();//BiomeBank.calculateBiome(tw,tw.getTemperature(rawX, rawZ), y).getHandler().getBiome();//Biome.valueOf(ica
-        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase());
+        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase(Locale.ENGLISH));
     }
 
      @Override

--- a/implementation/v1_19_R3/src/main/java/org/terraform/v1_19_R3/CustomBiomeHandler.java
+++ b/implementation/v1_19_R3/src/main/java/org/terraform/v1_19_R3/CustomBiomeHandler.java
@@ -24,6 +24,7 @@ import org.terraform.main.TerraformGeneratorPlugin;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class CustomBiomeHandler {
@@ -70,7 +71,7 @@ public class CustomBiomeHandler {
 						registrywritable,
 						forestbiome
 						);
-				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase());
+				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase(Locale.ENGLISH));
 			} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
 				TerraformGeneratorPlugin.logger.error("Failed to register custom biome: " + type.getKey());
 				e.printStackTrace();
@@ -94,7 +95,7 @@ public class CustomBiomeHandler {
 
 	private static void registerCustomBiomeBase(CustomBiomeType biomeType, DedicatedServer dedicatedserver, IRegistryWritable<BiomeBase> registrywritable, BiomeBase forestbiome) throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
 
-		ResourceKey<BiomeBase> newKey = ResourceKey.a(Registries.an, new MinecraftKey("terraformgenerator", biomeType.toString().toLowerCase()));
+		ResourceKey<BiomeBase> newKey = ResourceKey.a(Registries.an, new MinecraftKey("terraformgenerator", biomeType.toString().toLowerCase(Locale.ENGLISH)));
 
 		//BiomeBase.a is BiomeBuilder
 		BiomeBase.a newBiomeBuilder = new BiomeBase.a();

--- a/implementation/v1_19_R3/src/main/java/org/terraform/v1_19_R3/PopulatorData.java
+++ b/implementation/v1_19_R3/src/main/java/org/terraform/v1_19_R3/PopulatorData.java
@@ -32,6 +32,7 @@ import org.terraform.data.TerraformWorld;
 import org.terraform.main.TerraformGeneratorPlugin;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Random;
 
@@ -58,7 +59,7 @@ public class PopulatorData extends PopulatorDataAbstract implements IPopulatorDa
         		if(type == EntityType.UNKNOWN) continue;
 				try {
                     //EntityTypes.byString
-					Optional<EntityTypes<?>> et = EntityTypes.a("minecraft:"+type.toString().toLowerCase());
+					Optional<EntityTypes<?>> et = EntityTypes.a("minecraft:"+type.toString().toLowerCase(Locale.ENGLISH));
                     //EntityTypes<?> et = (EntityTypes<?>) EntityTypes.class.getDeclaredField(EntityTypeMapper.getObfsNameFromBukkitEntityType(type)).get(null);
                     //TerraformGeneratorPlugin.logger.info(type + ":" + et.isPresent());
                     et.ifPresent(entityTypes -> entityTypesDict.put(type, entityTypes));

--- a/implementation/v1_19_R3/src/main/java/org/terraform/v1_19_R3/PopulatorDataICA.java
+++ b/implementation/v1_19_R3/src/main/java/org/terraform/v1_19_R3/PopulatorDataICA.java
@@ -127,7 +127,7 @@ public class PopulatorDataICA extends PopulatorDataICABiomeWriterAbstract {
     public Biome getBiome(int rawX, int rawZ) {
     	return parent.getBiome(rawX, rawZ);
         //return tw.getBiomeBank(rawX, rawZ).getHandler().getBiome();//BiomeBank.calculateBiome(tw,tw.getTemperature(rawX, rawZ), y).getHandler().getBiome();//Biome.valueOf(ica
-        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase());
+        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase(Locale.ENGLISH));
     }
 
      @Override

--- a/implementation/v1_20_R1/src/main/java/org/terraform/v1_20_R1/CustomBiomeHandler.java
+++ b/implementation/v1_20_R1/src/main/java/org/terraform/v1_20_R1/CustomBiomeHandler.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -78,7 +79,7 @@ public class CustomBiomeHandler {
 						registrywritable,
 						forestbiome
 						);
-				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase());
+				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase(Locale.ENGLISH));
 			} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException |
                      NoSuchMethodException | InvocationTargetException e) {
 				TerraformGeneratorPlugin.logger.error("Failed to register custom biome: " + type.getKey());
@@ -103,7 +104,7 @@ public class CustomBiomeHandler {
 
 	private static void registerCustomBiomeBase(CustomBiomeType biomeType, DedicatedServer dedicatedserver, IRegistryWritable<BiomeBase> registrywritable, BiomeBase forestbiome) throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 
-		ResourceKey<BiomeBase> newKey = ResourceKey.a(Registries.ap, new MinecraftKey("terraformgenerator", biomeType.toString().toLowerCase()));
+		ResourceKey<BiomeBase> newKey = ResourceKey.a(Registries.ap, new MinecraftKey("terraformgenerator", biomeType.toString().toLowerCase(Locale.ENGLISH)));
 
 		//BiomeBase.a is BiomeBuilder
 		BiomeBase.a newBiomeBuilder = new BiomeBase.a();

--- a/implementation/v1_20_R1/src/main/java/org/terraform/v1_20_R1/PopulatorDataICA.java
+++ b/implementation/v1_20_R1/src/main/java/org/terraform/v1_20_R1/PopulatorDataICA.java
@@ -127,7 +127,7 @@ public class PopulatorDataICA extends PopulatorDataICABiomeWriterAbstract {
     public Biome getBiome(int rawX, int rawZ) {
     	return parent.getBiome(rawX, rawZ);
         //return tw.getBiomeBank(rawX, rawZ).getHandler().getBiome();//BiomeBank.calculateBiome(tw,tw.getTemperature(rawX, rawZ), y).getHandler().getBiome();//Biome.valueOf(ica
-        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase());
+        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase(Locale.ENGLISH));
     }
 
      @Override

--- a/implementation/v1_20_R2/src/main/java/org/terraform/v1_20_R2/CustomBiomeHandler.java
+++ b/implementation/v1_20_R2/src/main/java/org/terraform/v1_20_R2/CustomBiomeHandler.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -79,7 +80,7 @@ public class CustomBiomeHandler {
 						registrywritable,
 						forestbiome
 						);
-				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase());
+				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase(Locale.ENGLISH));
 			} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException |
                      NoSuchMethodException | InvocationTargetException e) {
 				TerraformGeneratorPlugin.logger.error("Failed to register custom biome: " + type.getKey());
@@ -104,7 +105,7 @@ public class CustomBiomeHandler {
 
 	private static void registerCustomBiomeBase(CustomBiomeType biomeType, DedicatedServer dedicatedserver, IRegistryWritable<BiomeBase> registrywritable, BiomeBase forestbiome) throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 
-		ResourceKey<BiomeBase> newKey = ResourceKey.a(Registries.ap, new MinecraftKey("terraformgenerator", biomeType.toString().toLowerCase()));
+		ResourceKey<BiomeBase> newKey = ResourceKey.a(Registries.ap, new MinecraftKey("terraformgenerator", biomeType.toString().toLowerCase(Locale.ENGLISH)));
 
 		//BiomeBase.a is BiomeBuilder
 		BiomeBase.a newBiomeBuilder = new BiomeBase.a();

--- a/implementation/v1_20_R2/src/main/java/org/terraform/v1_20_R2/PopulatorDataICA.java
+++ b/implementation/v1_20_R2/src/main/java/org/terraform/v1_20_R2/PopulatorDataICA.java
@@ -131,7 +131,7 @@ public class PopulatorDataICA extends PopulatorDataICABiomeWriterAbstract {
     public Biome getBiome(int rawX, int rawZ) {
     	return parent.getBiome(rawX, rawZ);
         //return tw.getBiomeBank(rawX, rawZ).getHandler().getBiome();//BiomeBank.calculateBiome(tw,tw.getTemperature(rawX, rawZ), y).getHandler().getBiome();//Biome.valueOf(ica
-        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase());
+        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase(Locale.ENGLISH));
     }
 
      @Override

--- a/implementation/v1_20_R3/src/main/java/org/terraform/v1_20_R3/CustomBiomeHandler.java
+++ b/implementation/v1_20_R3/src/main/java/org/terraform/v1_20_R3/CustomBiomeHandler.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -78,7 +79,7 @@ public class CustomBiomeHandler {
 						registrywritable,
 						forestbiome
 						);
-				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase());
+				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase(Locale.ENGLISH));
 			} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException |
                      NoSuchMethodException | InvocationTargetException e) {
 				TerraformGeneratorPlugin.logger.error("Failed to register custom biome: " + type.getKey());
@@ -103,7 +104,7 @@ public class CustomBiomeHandler {
 
 	private static void registerCustomBiomeBase(CustomBiomeType biomeType, DedicatedServer dedicatedserver, IRegistryWritable<BiomeBase> registrywritable, BiomeBase forestbiome) throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
 
-		ResourceKey<BiomeBase> newKey = ResourceKey.a(Registries.at, new MinecraftKey("terraformgenerator", biomeType.toString().toLowerCase()));
+		ResourceKey<BiomeBase> newKey = ResourceKey.a(Registries.at, new MinecraftKey("terraformgenerator", biomeType.toString().toLowerCase(Locale.ENGLISH)));
 
 		//BiomeBase.a is BiomeBuilder
 		BiomeBase.a newBiomeBuilder = new BiomeBase.a();

--- a/implementation/v1_20_R3/src/main/java/org/terraform/v1_20_R3/PopulatorData.java
+++ b/implementation/v1_20_R3/src/main/java/org/terraform/v1_20_R3/PopulatorData.java
@@ -32,6 +32,7 @@ import org.terraform.data.TerraformWorld;
 import org.terraform.main.TerraformGeneratorPlugin;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Random;
 
@@ -58,7 +59,7 @@ public class PopulatorData extends PopulatorDataAbstract implements IPopulatorDa
         		if(type == EntityType.UNKNOWN) continue;
 				try {
                     //EntityTypes.byString
-					Optional<EntityTypes<?>> et = EntityTypes.a("minecraft:"+type.toString().toLowerCase());
+					Optional<EntityTypes<?>> et = EntityTypes.a("minecraft:"+type.toString().toLowerCase(Locale.ENGLISH));
                     //EntityTypes<?> et = (EntityTypes<?>) EntityTypes.class.getDeclaredField(EntityTypeMapper.getObfsNameFromBukkitEntityType(type)).get(null);
                     //TerraformGeneratorPlugin.logger.info(type + ":" + et.isPresent());
                     et.ifPresent(entityTypes -> entityTypesDict.put(type, entityTypes));

--- a/implementation/v1_20_R3/src/main/java/org/terraform/v1_20_R3/PopulatorDataICA.java
+++ b/implementation/v1_20_R3/src/main/java/org/terraform/v1_20_R3/PopulatorDataICA.java
@@ -127,7 +127,7 @@ public class PopulatorDataICA extends PopulatorDataICABiomeWriterAbstract {
     public Biome getBiome(int rawX, int rawZ) {
     	return parent.getBiome(rawX, rawZ);
         //return tw.getBiomeBank(rawX, rawZ).getHandler().getBiome();//BiomeBank.calculateBiome(tw,tw.getTemperature(rawX, rawZ), y).getHandler().getBiome();//Biome.valueOf(ica
-        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase());
+        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase(Locale.ENGLISH));
     }
 
      @Override

--- a/implementation/v1_20_R4/src/main/java/org/terraform/v1_20_R4/CustomBiomeHandler.java
+++ b/implementation/v1_20_R4/src/main/java/org/terraform/v1_20_R4/CustomBiomeHandler.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -80,7 +81,7 @@ public class CustomBiomeHandler {
 						registrywritable,
 						forestbiome
 						);
-				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase());
+				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase(Locale.ENGLISH));
 			} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException |
                      NoSuchMethodException | InvocationTargetException e) {
 				TerraformGeneratorPlugin.logger.error("Failed to register custom biome: " + type.getKey());
@@ -113,7 +114,7 @@ public class CustomBiomeHandler {
         RegistrationInfo regInfo = (RegistrationInfo) defaultRegInfoField.get(null);
 
         //az is BIOME
-		ResourceKey<BiomeBase> newKey = ResourceKey.a(Registries.az, new MinecraftKey("terraformgenerator", biomeType.toString().toLowerCase()));
+		ResourceKey<BiomeBase> newKey = ResourceKey.a(Registries.az, new MinecraftKey("terraformgenerator", biomeType.toString().toLowerCase(Locale.ENGLISH)));
 
 		//BiomeBase.a is BiomeBuilder
 		BiomeBase.a newBiomeBuilder = new BiomeBase.a();

--- a/implementation/v1_20_R4/src/main/java/org/terraform/v1_20_R4/PopulatorData.java
+++ b/implementation/v1_20_R4/src/main/java/org/terraform/v1_20_R4/PopulatorData.java
@@ -33,6 +33,7 @@ import org.terraform.main.TerraformGeneratorPlugin;
 import org.terraform.utils.GenUtils;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Random;
 
@@ -58,7 +59,7 @@ public class PopulatorData extends PopulatorDataAbstract implements IPopulatorDa
         		if(type == EntityType.UNKNOWN) continue;
 				try {
                     //EntityTypes.byString
-					Optional<EntityTypes<?>> et = EntityTypes.a("minecraft:"+type.toString().toLowerCase());
+					Optional<EntityTypes<?>> et = EntityTypes.a("minecraft:"+type.toString().toLowerCase(Locale.ENGLISH));
                     //EntityTypes<?> et = (EntityTypes<?>) EntityTypes.class.getDeclaredField(EntityTypeMapper.getObfsNameFromBukkitEntityType(type)).get(null);
                     //TerraformGeneratorPlugin.logger.info(type + ":" + et.isPresent());
                     et.ifPresent(entityTypes -> entityTypesDict.put(type, entityTypes));

--- a/implementation/v1_20_R4/src/main/java/org/terraform/v1_20_R4/PopulatorDataICA.java
+++ b/implementation/v1_20_R4/src/main/java/org/terraform/v1_20_R4/PopulatorDataICA.java
@@ -127,7 +127,7 @@ public class PopulatorDataICA extends PopulatorDataICABiomeWriterAbstract {
     public Biome getBiome(int rawX, int rawZ) {
     	return parent.getBiome(rawX, rawZ);
         //return tw.getBiomeBank(rawX, rawZ).getHandler().getBiome();//BiomeBank.calculateBiome(tw,tw.getTemperature(rawX, rawZ), y).getHandler().getBiome();//Biome.valueOf(ica
-        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase());
+        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase(Locale.ENGLISH));
     }
 
      @Override

--- a/implementation/v1_21_R1/src/main/java/org/terraform/v1_21_R1/CustomBiomeHandler.java
+++ b/implementation/v1_21_R1/src/main/java/org/terraform/v1_21_R1/CustomBiomeHandler.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -78,7 +79,7 @@ public class CustomBiomeHandler {
 						registrywritable,
 						forestbiome
 						);
-				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase());
+				TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase(Locale.ENGLISH));
 			} catch (Throwable e) {
 				TerraformGeneratorPlugin.logger.error("Failed to register custom biome: " + type.getKey());
 				e.printStackTrace();
@@ -110,7 +111,7 @@ public class CustomBiomeHandler {
         Object regInfo = defaultRegInfoField.get(null);
 
         //az is BIOME
-		ResourceKey<BiomeBase> newKey = ResourceKey.a(Registries.aF, MinecraftKey.a("terraformgenerator", biomeType.toString().toLowerCase()));
+		ResourceKey<BiomeBase> newKey = ResourceKey.a(Registries.aF, MinecraftKey.a("terraformgenerator", biomeType.toString().toLowerCase(Locale.ENGLISH)));
 
 		//BiomeBase.a is BiomeBuilder
 		BiomeBase.a newBiomeBuilder = new BiomeBase.a();

--- a/implementation/v1_21_R1/src/main/java/org/terraform/v1_21_R1/PopulatorData.java
+++ b/implementation/v1_21_R1/src/main/java/org/terraform/v1_21_R1/PopulatorData.java
@@ -33,6 +33,7 @@ import org.terraform.main.TerraformGeneratorPlugin;
 import org.terraform.utils.GenUtils;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Random;
 
@@ -58,7 +59,7 @@ public class PopulatorData extends PopulatorDataAbstract implements IPopulatorDa
         		if(type == EntityType.UNKNOWN) continue;
 				try {
                     //EntityTypes.byString
-					Optional<EntityTypes<?>> et = EntityTypes.a("minecraft:"+type.toString().toLowerCase());
+					Optional<EntityTypes<?>> et = EntityTypes.a("minecraft:"+type.toString().toLowerCase(Locale.ENGLISH));
                     //EntityTypes<?> et = (EntityTypes<?>) EntityTypes.class.getDeclaredField(EntityTypeMapper.getObfsNameFromBukkitEntityType(type)).get(null);
                     //TerraformGeneratorPlugin.logger.info(type + ":" + et.isPresent());
                     et.ifPresent(entityTypes -> entityTypesDict.put(type, entityTypes));

--- a/implementation/v1_21_R1/src/main/java/org/terraform/v1_21_R1/PopulatorDataICA.java
+++ b/implementation/v1_21_R1/src/main/java/org/terraform/v1_21_R1/PopulatorDataICA.java
@@ -127,7 +127,7 @@ public class PopulatorDataICA extends PopulatorDataICABiomeWriterAbstract {
     public Biome getBiome(int rawX, int rawZ) {
     	return parent.getBiome(rawX, rawZ);
         //return tw.getBiomeBank(rawX, rawZ).getHandler().getBiome();//BiomeBank.calculateBiome(tw,tw.getTemperature(rawX, rawZ), y).getHandler().getBiome();//Biome.valueOf(ica
-        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase());
+        // .getBiome(rawX, rawY, rawZ).l().replace("biome.minecraft.", "").toUpperCase(Locale.ENGLISH));
     }
 
      @Override


### PR DESCRIPTION
By default, calling String.toUpperCase() and toLowerCase() returns the converted string in the default locale of the current JVM. In some locales such as Turkish this causes some characters to have unexpected mappings - such as with the `I` and `i` characters - creating invalid resource names.

This patch addresses this and any other potential case conversion issue by making all case conversions work in English.

---

Note that some commented out lines in some files such as `implementation/v1_19_R3/src/main/java/org/terraform/v1_19_R3/PopulatorDataICA.java` were also changed, but the required import was not to these files, as it would've been unnecessary.

I tested a new build with these changes myself in a server with only this plugin, and everything worked fine. The error was fixed with no obvious side effects.