### PR TITLE
Fix: Resolve type casting issues in custom biome registration for Min…

### DIFF
--- a/common/src/main/java/org/terraform/biome/BiomeBank.java
+++ b/common/src/main/java/org/terraform/biome/BiomeBank.java
@@ -251,7 +251,7 @@ public enum BiomeBank {
             BiomeClimate.DRY_VEGETATION,
             TConfig.c.BIOME_SAVANNA_WEIGHT
     ),
-    MUDDY_BOG(new MuddyBogHandler(),
+    SUNFORGED_LAND(new MuddyBogHandler(),
             BiomeType.FLAT,
             BiomeClimate.DRY_VEGETATION,
             TConfig.c.BIOME_MUDDYBOG_WEIGHT
@@ -282,12 +282,12 @@ public enum BiomeBank {
             BiomeClimate.COLD,
             TConfig.c.BIOME_ERODED_PLAINS_WEIGHT
     ),
-    SCARLET_FOREST(new ScarletForestHandler(),
+    LEAFSTRIDER_LAND(new ScarletForestHandler(),
             BiomeType.FLAT,
             BiomeClimate.COLD,
             TConfig.c.BIOME_SCARLETFOREST_WEIGHT
     ),
-    CHERRY_GROVE(new CherryGroveHandler(),
+    GLACIERBORN_LAND(new CherryGroveHandler(),
             BiomeType.FLAT,
             BiomeClimate.COLD,
             TConfig.c.BIOME_CHERRYGROVE_WEIGHT

--- a/common/src/main/java/org/terraform/biome/beach/BogBeachHandler.java
+++ b/common/src/main/java/org/terraform/biome/beach/BogBeachHandler.java
@@ -30,7 +30,7 @@ public class BogBeachHandler extends BiomeHandler {
 
     @Override
     public @NotNull CustomBiomeType getCustomBiome() {
-        return CustomBiomeType.MUDDY_BOG;
+        return CustomBiomeType.SUNFORGED_LAND;
     }
 
     @Override

--- a/common/src/main/java/org/terraform/biome/beach/CherryGroveBeachHandler.java
+++ b/common/src/main/java/org/terraform/biome/beach/CherryGroveBeachHandler.java
@@ -26,7 +26,7 @@ public class CherryGroveBeachHandler extends BiomeHandler {
 
     @Override
     public @NotNull CustomBiomeType getCustomBiome() {
-        return CustomBiomeType.CHERRY_GROVE;
+        return CustomBiomeType.GLACIERBORN_LAND;
     }
 
     @Override

--- a/common/src/main/java/org/terraform/biome/beach/ScarletForestBeachHandler.java
+++ b/common/src/main/java/org/terraform/biome/beach/ScarletForestBeachHandler.java
@@ -25,7 +25,7 @@ public class ScarletForestBeachHandler extends BiomeHandler {
 
     @Override
     public @NotNull CustomBiomeType getCustomBiome() {
-        return CustomBiomeType.SCARLET_FOREST;
+        return CustomBiomeType.LEAFSTRIDER_LAND;
     }
 
     @Override

--- a/common/src/main/java/org/terraform/biome/custombiomes/CustomBiomeType.java
+++ b/common/src/main/java/org/terraform/biome/custombiomes/CustomBiomeType.java
@@ -7,9 +7,9 @@ import java.util.Locale;
 
 public enum CustomBiomeType {
     NONE,
-    MUDDY_BOG("b8ad49", "9c8046", "b8ad49", "d9cd62", "ad8445", "ad8445"),
-    CHERRY_GROVE("", "69faff", "", "87fffb", "ffa1fc", "acff96"),
-    SCARLET_FOREST("", "", "", "", "fc3103", "ff7700"),
+    SUNFORGED_LAND("b8ad49", "9c8046", "b8ad49", "d9cd62", "ad8445", "ad8445"),
+    GLACIERBORN_LAND("", "69faff", "", "87fffb", "ffa1fc", "acff96"),
+    LEAFSTRIDER_LAND("", "", "", "", "fc3103", "ff7700"),
     CRYSTALLINE_CLUSTER("e54fff", "c599ff", "e54fff", "", "", ""),
     ;
 
@@ -24,7 +24,7 @@ public enum CustomBiomeType {
     private boolean isCold = false;
 
     CustomBiomeType() {
-        this.key = "terraformgenerator:" + this.toString().toLowerCase(Locale.ENGLISH);
+        this.key = "MysticBiomes:" + this.toString().toLowerCase(Locale.ENGLISH);
         this.fogColor = "";
         this.waterColor = "";
         this.waterFogColor = "";
@@ -40,7 +40,7 @@ public enum CustomBiomeType {
                     String foliageColor,
                     String grassColor)
     {
-        this.key = "terraformgenerator:" + this.toString().toLowerCase(Locale.ENGLISH);
+        this.key = "MysticBiomes:" + this.toString().toLowerCase(Locale.ENGLISH);
         this.fogColor = fogColor;
         this.waterColor = waterColor;
         this.waterFogColor = waterFogColor;

--- a/common/src/main/java/org/terraform/biome/flat/CherryGroveHandler.java
+++ b/common/src/main/java/org/terraform/biome/flat/CherryGroveHandler.java
@@ -37,7 +37,7 @@ public class CherryGroveHandler extends BiomeHandler {
 
     @Override
     public @NotNull CustomBiomeType getCustomBiome() {
-        return CustomBiomeType.CHERRY_GROVE;
+        return CustomBiomeType.GLACIERBORN_LAND;
     }
 
     @Override
@@ -103,7 +103,7 @@ public class CherryGroveHandler extends BiomeHandler {
             int treeY = GenUtils.getHighestGround(data, sLoc.getX(), sLoc.getZ());
             sLoc.setY(treeY);
 
-            if (tw.getBiomeBank(sLoc.getX(), sLoc.getZ()) == BiomeBank.CHERRY_GROVE
+            if (tw.getBiomeBank(sLoc.getX(), sLoc.getZ()) == BiomeBank.GLACIERBORN_LAND
                 && BlockUtils.isDirtLike(data.getType(sLoc.getX(), sLoc.getY(), sLoc.getZ())))
             {
                 switch (random.nextInt(20)) // 0 to 19 inclusive

--- a/common/src/main/java/org/terraform/biome/flat/MuddyBogHandler.java
+++ b/common/src/main/java/org/terraform/biome/flat/MuddyBogHandler.java
@@ -39,7 +39,7 @@ public class MuddyBogHandler extends BiomeHandler {
 
     @Override
     public @NotNull CustomBiomeType getCustomBiome() {
-        return CustomBiomeType.MUDDY_BOG;
+        return CustomBiomeType.SUNFORGED_LAND;
     }
 
     // Beach type. This will be used instead if the height is too close to sea level.
@@ -141,7 +141,7 @@ public class MuddyBogHandler extends BiomeHandler {
     }
 
     private boolean isRightBiome(BiomeBank bank) {
-        return bank == BiomeBank.MUDDY_BOG || bank == BiomeBank.BOG_BEACH;
+        return bank == BiomeBank.SUNFORGED_LAND || bank == BiomeBank.BOG_BEACH;
     }
 
     @Override

--- a/common/src/main/java/org/terraform/biome/flat/ScarletForestHandler.java
+++ b/common/src/main/java/org/terraform/biome/flat/ScarletForestHandler.java
@@ -33,7 +33,7 @@ public class ScarletForestHandler extends BiomeHandler {
 
     @Override
     public @NotNull CustomBiomeType getCustomBiome() {
-        return CustomBiomeType.SCARLET_FOREST;
+        return CustomBiomeType.LEAFSTRIDER_LAND;
     }
 
     @Override
@@ -86,7 +86,7 @@ public class ScarletForestHandler extends BiomeHandler {
             int treeY = GenUtils.getHighestGround(data, sLoc.getX(), sLoc.getZ());
             sLoc.setY(treeY);
 
-            if (tw.getBiomeBank(sLoc.getX(), sLoc.getZ()) == BiomeBank.SCARLET_FOREST
+            if (tw.getBiomeBank(sLoc.getX(), sLoc.getZ()) == BiomeBank.LEAFSTRIDER_LAND
                 && BlockUtils.isDirtLike(data.getType(sLoc.getX(), sLoc.getY(), sLoc.getZ())))
             {
                 if (TConfig.c.TREES_SCARLET_BIG_ENABLED) {

--- a/common/src/main/java/org/terraform/biome/river/BogRiverHandler.java
+++ b/common/src/main/java/org/terraform/biome/river/BogRiverHandler.java
@@ -37,7 +37,7 @@ public class BogRiverHandler extends BiomeHandler {
 
     @Override
     public @NotNull CustomBiomeType getCustomBiome() {
-        return CustomBiomeType.MUDDY_BOG;
+        return CustomBiomeType.SUNFORGED_LAND;
     }
 
 
@@ -89,7 +89,7 @@ public class BogRiverHandler extends BiomeHandler {
                 int height = (int) Math.round((maxHeight * noise));
 
                 if (tw.getBiomeBank(rawX, rawZ) != BiomeBank.BOG_RIVER
-                    && tw.getBiomeBank(rawX, rawZ) != BiomeBank.MUDDY_BOG
+                    && tw.getBiomeBank(rawX, rawZ) != BiomeBank.SUNFORGED_LAND
                     && tw.getBiomeBank(rawX, rawZ) != BiomeBank.BOG_BEACH)
                 {
                     height = 0;

--- a/common/src/main/java/org/terraform/biome/river/CherryGroveRiverHandler.java
+++ b/common/src/main/java/org/terraform/biome/river/CherryGroveRiverHandler.java
@@ -28,7 +28,7 @@ public class CherryGroveRiverHandler extends BiomeHandler {
 
     @Override
     public @NotNull CustomBiomeType getCustomBiome() {
-        return CustomBiomeType.CHERRY_GROVE;
+        return CustomBiomeType.GLACIERBORN_LAND;
     }
 
     @Override

--- a/common/src/main/java/org/terraform/biome/river/ScarletForestRiverHandler.java
+++ b/common/src/main/java/org/terraform/biome/river/ScarletForestRiverHandler.java
@@ -28,7 +28,7 @@ public class ScarletForestRiverHandler extends BiomeHandler {
 
     @Override
     public @NotNull CustomBiomeType getCustomBiome() {
-        return CustomBiomeType.SCARLET_FOREST;
+        return CustomBiomeType.LEAFSTRIDER_LAND;
     }
 
     @Override

--- a/common/src/main/java/org/terraform/structure/catacombs/CatacombsPopulator.java
+++ b/common/src/main/java/org/terraform/structure/catacombs/CatacombsPopulator.java
@@ -42,15 +42,15 @@ public class CatacombsPopulator extends SingleMegaChunkStructurePopulator {
 
         // Don't compete with villages for space. In future, this may be changed
         // to allow multiple structures per megachunk
-        if (biome == (BiomeBank.PLAINS)
-            || biome == (BiomeBank.FOREST)
-            || biome == (BiomeBank.SAVANNA)
-            || biome == (BiomeBank.TAIGA)
-            || biome == (BiomeBank.SCARLET_FOREST)
-            || biome == (BiomeBank.CHERRY_GROVE))
-        {
-            return false;
-        }
+        //if (biome == (BiomeBank.PLAINS)
+        //    || biome == (BiomeBank.FOREST)
+        //    || biome == (BiomeBank.SAVANNA)
+        //    || biome == (BiomeBank.TAIGA)
+        //    || biome == (BiomeBank.LEAFSTRIDER_LAND)
+        //    || biome == (BiomeBank.GLACIERBORN_LAND))
+        //{
+        //    return false;
+        //}
 
         // Do height and space checks
         int height = HeightMap.getBlockHeight(tw, coords[0], coords[1]);

--- a/common/src/main/java/org/terraform/structure/pyramid/PyramidPopulator.java
+++ b/common/src/main/java/org/terraform/structure/pyramid/PyramidPopulator.java
@@ -494,6 +494,9 @@ public class PyramidPopulator extends SingleMegaChunkStructurePopulator {
         // TODO Auto-generated method stub
         return TConfig.areStructuresEnabled()
                && BiomeBank.isBiomeEnabled(BiomeBank.DESERT)
+               || BiomeBank.isBiomeEnabled(BiomeBank.LEAFSTRIDER_LAND)
+               || BiomeBank.isBiomeEnabled(BiomeBank.SUNFORGED_LAND)
+               || BiomeBank.isBiomeEnabled(BiomeBank.GLACIERBORN_LAND)
                && TConfig.c.STRUCTURES_PYRAMID_ENABLED;
     }
 

--- a/common/src/main/java/org/terraform/structure/trailruins/TrailRuinsPopulator.java
+++ b/common/src/main/java/org/terraform/structure/trailruins/TrailRuinsPopulator.java
@@ -105,6 +105,9 @@ public class TrailRuinsPopulator extends SingleMegaChunkStructurePopulator {
                && (BiomeBank.isBiomeEnabled(BiomeBank.TAIGA)
                    || BiomeBank.isBiomeEnabled(BiomeBank.SNOWY_TAIGA)
                    || BiomeBank.isBiomeEnabled(BiomeBank.JUNGLE))
+                   || BiomeBank.isBiomeEnabled(BiomeBank.LEAFSTRIDER_LAND)
+                   || BiomeBank.isBiomeEnabled(BiomeBank.SUNFORGED_LAND)
+                   || BiomeBank.isBiomeEnabled(BiomeBank.GLACIERBORN_LAND)
                && TConfig.c.STRUCTURES_TRAILRUINS_ENABLED;
     }
 

--- a/common/src/main/java/org/terraform/structure/village/VillagePopulator.java
+++ b/common/src/main/java/org/terraform/structure/village/VillagePopulator.java
@@ -42,8 +42,9 @@ public class VillagePopulator extends SingleMegaChunkStructurePopulator {
             || biome == (BiomeBank.FOREST)
             || biome == (BiomeBank.SAVANNA)
             || biome == (BiomeBank.TAIGA)
-            || biome == (BiomeBank.SCARLET_FOREST)
-            || biome == (BiomeBank.CHERRY_GROVE))
+            || biome == (BiomeBank.SUNFORGED_LAND)
+            || biome == (BiomeBank.GLACIERBORN_LAND)
+            || biome == (BiomeBank.LEAFSTRIDER_LAND))
         {
 
             return rollSpawnRatio(tw, chunkX, chunkZ);
@@ -72,8 +73,8 @@ public class VillagePopulator extends SingleMegaChunkStructurePopulator {
         //       		|| banks.contains(BiomeBank.FOREST)
         //       		|| banks.contains(BiomeBank.SAVANNA)
         //       		|| banks.contains(BiomeBank.TAIGA)
-        //       		|| banks.contains(BiomeBank.SCARLET_FOREST)
-        //       		|| banks.contains(BiomeBank.CHERRY_GROVE)) {
+        //       		|| banks.contains(BiomeBank.LEAFSTRIDER_LAND)
+        //       		|| banks.contains(BiomeBank.GLACIERBORN_LAND)) {
 
         new PlainsVillagePopulator().populate(tw, data);
         //        }
@@ -93,8 +94,9 @@ public class VillagePopulator extends SingleMegaChunkStructurePopulator {
                    || BiomeBank.isBiomeEnabled(BiomeBank.FOREST)
                    || BiomeBank.isBiomeEnabled(BiomeBank.SAVANNA)
                    || BiomeBank.isBiomeEnabled(BiomeBank.TAIGA)
-                   || BiomeBank.isBiomeEnabled(BiomeBank.SCARLET_FOREST)
-                   || BiomeBank.isBiomeEnabled(BiomeBank.CHERRY_GROVE))
+                   || BiomeBank.isBiomeEnabled(BiomeBank.LEAFSTRIDER_LAND)
+                   || BiomeBank.isBiomeEnabled(BiomeBank.SUNFORGED_LAND)
+                   || BiomeBank.isBiomeEnabled(BiomeBank.GLACIERBORN_LAND))
                && TConfig.c.STRUCTURES_PLAINSVILLAGE_ENABLED;
     }
 }

--- a/common/src/main/java/org/terraform/utils/WoodUtils.java
+++ b/common/src/main/java/org/terraform/utils/WoodUtils.java
@@ -11,7 +11,7 @@ public class WoodUtils {
         return switch (biome) {
             case BADLANDS, BADLANDS_RIVER, SAVANNA, DESERT_MOUNTAINS, DESERT, DESERT_RIVER, BADLANDS_BEACH,
                  BADLANDS_CANYON -> wood.getWood(WoodSpecies.ACACIA);
-            case BIRCH_MOUNTAINS, SCARLET_FOREST -> wood.getWood(WoodSpecies.BIRCH);
+            case BIRCH_MOUNTAINS, LEAFSTRIDER_LAND -> wood.getWood(WoodSpecies.BIRCH);
             case COLD_OCEAN, WARM_OCEAN, SWAMP, PLAINS, OCEAN, MUDFLATS, CORAL_REEF_OCEAN, DEEP_LUKEWARM_OCEAN,
                  DEEP_OCEAN, DEEP_WARM_OCEAN, DEEP_DRY_OCEAN, DEEP_HUMID_OCEAN, DRY_OCEAN, HUMID_OCEAN, RIVER,
                  ERODED_PLAINS, FOREST -> wood.getWood(WoodSpecies.OAK);
@@ -19,7 +19,7 @@ public class WoodUtils {
                  FROZEN_RIVER, DEEP_COLD_OCEAN, DEEP_FROZEN_OCEAN, ICY_BEACH, ICE_SPIKES ->
                     wood.getWood(WoodSpecies.SPRUCE);
             case SANDY_BEACH, JUNGLE, JUNGLE_RIVER, BAMBOO_FOREST -> wood.getWood(WoodSpecies.JUNGLE);
-            case BLACK_OCEAN, DEEP_BLACK_OCEAN, CHERRY_GROVE, DARK_FOREST, DARK_FOREST_RIVER, DARK_FOREST_BEACH ->
+            case BLACK_OCEAN, DEEP_BLACK_OCEAN, GLACIERBORN_LAND, DARK_FOREST, DARK_FOREST_RIVER, DARK_FOREST_BEACH ->
                     wood.getWood(WoodSpecies.DARK_OAK);
             default -> wood.getWood(WoodSpecies.OAK);
         };

--- a/common/src/main/resources/plugin.yml
+++ b/common/src/main/resources/plugin.yml
@@ -1,8 +1,8 @@
-name: TerraformGenerator
-author: Hex_27
+name: MysticBiomes
+author: BadgersMC
 version: 16.2.0
 api-version: 1.18
-description: World Generator
+description: World Generator for play.mysticdominions.com
 main: org.terraform.main.TerraformGeneratorPlugin
 load: STARTUP
 folia-supported: true

--- a/implementation/v1_21_R1/src/main/java/org/terraform/v1_21_R1/CustomBiomeHandler.java
+++ b/implementation/v1_21_R1/src/main/java/org/terraform/v1_21_R1/CustomBiomeHandler.java
@@ -28,11 +28,7 @@ public class CustomBiomeHandler {
 
     public static final HashMap<CustomBiomeType, ResourceKey<BiomeBase>> terraformGenBiomeRegistry = new HashMap<>();
 
-    public static IRegistry<BiomeBase> getBiomeRegistry()
-    {
-        // aF is BIOME
-        // bc is registryAccess
-        // d is registryOrThrow
+    public static IRegistry<BiomeBase> getBiomeRegistry() {
         return MinecraftServer.getServer().bc().d(Registries.aF);
     }
 
@@ -41,199 +37,147 @@ public class CustomBiomeHandler {
         DedicatedServer dedicatedserver = craftserver.getServer();
         IRegistryWritable<BiomeBase> registrywritable = (IRegistryWritable<BiomeBase>) getBiomeRegistry();
 
-        // This thing isn't actually writable, so we have to forcefully UNFREEZE IT
-        // l is frozen
+        // Unfreeze the biome registry
         try {
             Field frozen = RegistryMaterials.class.getDeclaredField("l");
             frozen.setAccessible(true);
             frozen.set(registrywritable, false);
             TerraformGeneratorPlugin.logger.info("Unfreezing biome registry...");
-        }
-        catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e1) {
+        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e1) {
             TerraformGeneratorPlugin.logger.stackTrace(e1);
         }
 
-        BiomeBase forestbiome = registrywritable.a(Biomes.i); // forest
+        BiomeBase forestbiome = registrywritable.a(Biomes.i); // Use forest biome as a base
 
         for (CustomBiomeType type : CustomBiomeType.values()) {
-            if (type == CustomBiomeType.NONE) {
-                continue;
-            }
+            if (type == CustomBiomeType.NONE) continue;
 
             try {
                 assert forestbiome != null;
                 registerCustomBiomeBase(type, dedicatedserver, registrywritable, forestbiome);
-                TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString()
-                                                                                       .toLowerCase(Locale.ENGLISH));
-            }
-            catch (Throwable e) {
+                TerraformGeneratorPlugin.logger.info("Registered custom biome: " + type.toString().toLowerCase(Locale.ENGLISH));
+            } catch (Throwable e) {
                 TerraformGeneratorPlugin.logger.error("Failed to register custom biome: " + type.getKey());
                 TerraformGeneratorPlugin.logger.stackTrace(e);
             }
         }
 
+        // Freeze the biome registry again
         try {
             Field frozen = RegistryMaterials.class.getDeclaredField("l");
             frozen.setAccessible(true);
             frozen.set(registrywritable, true);
             TerraformGeneratorPlugin.logger.info("Freezing biome registry");
-        }
-        catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e1) {
+        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e1) {
             TerraformGeneratorPlugin.logger.stackTrace(e1);
         }
-
     }
 
-    private static void registerCustomBiomeBase(@NotNull CustomBiomeType biomeType,
-                                                DedicatedServer dedicatedserver,
-                                                @NotNull IRegistryWritable<BiomeBase> registrywritable,
-                                                @NotNull BiomeBase forestbiome) throws Throwable
-    {
+    private static void registerCustomBiomeBase(
+            @NotNull CustomBiomeType biomeType,
+            DedicatedServer dedicatedserver,
+            @NotNull IRegistryWritable<BiomeBase> registrywritable,
+            @NotNull BiomeBase forestbiome
+    ) throws Throwable {
 
-        // be is reloadableRegistries()
-        // a is get()
-        // c is DEFAULT_REGISTRATION_INFO
-        Field defaultRegInfoField = ReloadableServerRegistries.class.getDeclaredField("c");
-        defaultRegInfoField.setAccessible(true);
-        Object regInfo = defaultRegInfoField.get(null);
-
-        // az is BIOME
+        // Adjusted namespace to "mysticbiomes"
         ResourceKey<BiomeBase> newKey = ResourceKey.a(
                 Registries.aF,
-                MinecraftKey.a("terraformgenerator", biomeType.toString().toLowerCase(Locale.ENGLISH))
+                MinecraftKey.a("mysticbiomes", biomeType.toString().toLowerCase(Locale.ENGLISH))
         );
 
-        // BiomeBase.a is BiomeBuilder
         BiomeBase.a newBiomeBuilder = new BiomeBase.a();
 
-        // BiomeBase.b is ClimateSettings
-        // d is temperatureModifier
-        // This temperature modifier stuff is more cleanly handled below.
-        //		Class<?> climateSettingsClass = Class.forName("net.minecraft.world.level.biome.BiomeBase.b");
-        //		Field temperatureModififierField = climateSettingsClass.getDeclaredField("d");
-        //		temperatureModififierField.setAccessible(true);
-
-        // i is climateSettings
-        newBiomeBuilder.a(forestbiome.c()); // c is getPrecipitation
-
-        // k is mobSettings
-        Field biomeSettingMobsField = BiomeBase.class.getDeclaredField("k");
-        biomeSettingMobsField.setAccessible(true);
-        BiomeSettingsMobs biomeSettingMobs = (BiomeSettingsMobs) biomeSettingMobsField.get(forestbiome);
-        newBiomeBuilder.a(biomeSettingMobs);
-
-        // j is generationSettings
-        Field biomeSettingGenField = BiomeBase.class.getDeclaredField("j");
-        biomeSettingGenField.setAccessible(true);
-        BiomeSettingsGeneration biomeSettingGen = (BiomeSettingsGeneration) biomeSettingGenField.get(forestbiome);
-        newBiomeBuilder.a(biomeSettingGen);
+        newBiomeBuilder.a(forestbiome.c()); // Precipitation
+        newBiomeBuilder.a(getBiomeSettingsMobs(forestbiome));
+        newBiomeBuilder.a(getBiomeSettingsGeneration(forestbiome));
 
         newBiomeBuilder.a(0.7F); // Temperature of biome
         newBiomeBuilder.b(biomeType.getRainFall()); // Downfall of biome
 
-        // BiomeBase.TemperatureModifier.a will make your biome normal
-        // BiomeBase.TemperatureModifier.b will make your biome frozen
         if (biomeType.isCold()) {
-            newBiomeBuilder.a(BiomeBase.TemperatureModifier.b);
-        }
-        else {
-            newBiomeBuilder.a(BiomeBase.TemperatureModifier.a);
+            newBiomeBuilder.a(BiomeBase.TemperatureModifier.b); // Frozen biome
+        } else {
+            newBiomeBuilder.a(BiomeBase.TemperatureModifier.a); // Normal biome
         }
 
         BiomeFog.a newFog = new BiomeFog.a();
-        newFog.a(GrassColor.a); // This doesn't affect the actual final grass color, just leave this line as it is or you will get errors
+        newFog.a(GrassColor.a); // Grass color placeholder
 
-        // Set biome colours. If field is empty, default to forest color
-
-        // fogcolor
-        newFog.a(biomeType.getFogColor().isEmpty() ? forestbiome.e() : Integer.parseInt(biomeType.getFogColor(), 16));
-
-        // water color i is getWaterColor
-        newFog.b(biomeType.getWaterColor().isEmpty()
-                 ? forestbiome.i()
-                 : Integer.parseInt(biomeType.getWaterColor(), 16));
-
-        // water fog color j is getWaterFogColor
-        newFog.c(biomeType.getWaterFogColor().isEmpty()
-                 ? forestbiome.j()
-                 : Integer.parseInt(biomeType.getWaterFogColor(), 16));
-
-        // sky color
-        newFog.d(biomeType.getSkyColor().isEmpty() ? forestbiome.a() : Integer.parseInt(biomeType.getSkyColor(), 16));
-
-
-        // Unnecessary values; can be removed safely if you don't want to change them
-
-        // foliage color (leaves, fines and more) f is getFoliageColor
-        newFog.e(biomeType.getFoliageColor().isEmpty()
-                 ? forestbiome.f()
-                 : Integer.parseInt(biomeType.getFoliageColor(), 16));
-
-        // grass blocks color
-        newFog.f(biomeType.getGrassColor().isEmpty()
-                 ? Integer.parseInt("79C05A", 16)
-                 : Integer.parseInt(biomeType.getGrassColor(), 16));
-
+        // Set biome colors, defaulting to forest biome colors if not specified
+        setBiomeColors(newFog, biomeType, forestbiome);
 
         newBiomeBuilder.a(newFog.a());
 
-        BiomeBase biome = newBiomeBuilder.a(); // biomebuilder.build();
+        BiomeBase biome = newBiomeBuilder.a(); // Build the biome
 
-        // Inject into the data registry for biomes
-        // RegistryGeneration.a(RegistryGeneration.i, newKey, biome);
-
-        // d is containsKey
         if (registrywritable.d(newKey)) {
             TerraformGeneratorPlugin.logger.info(newKey + " was already registered. Was there a plugin/server reload?");
             return;
         }
 
-        // Inject into the biome registry
-        // al is BIOMES
-        // aW is registryAccess
-        // d is registryOrThrow
-        // RegistryMaterials<BiomeBase> registry = (RegistryMaterials<BiomeBase>) getBiomeRegistry();
-
-        // Inject unregisteredIntrusiveHolders with a new map to allow intrusive holders
-        // m is unregisteredIntrusiveHolders
-        // Field unregisteredIntrusiveHolders = RegistryMaterials.class.getDeclaredField("m");
-        // unregisteredIntrusiveHolders.setAccessible(true);
-        // unregisteredIntrusiveHolders.set(registrywritable, new IdentityHashMap<>());
-
-        // f is createIntrusiveHolder
-        // registrywritable.f(biome);
-
-        // a is RegistryMaterials.register
-        // Holder.c is Holder.Reference
         Method register = registrywritable.getClass().getDeclaredMethod("a",
                 net.minecraft.resources.ResourceKey.class,
                 Object.class,
                 Class.forName("net.minecraft.core.RegistrationInfo")
         );
         register.setAccessible(true);
-        Holder.c<BiomeBase> holder = (Holder.c<BiomeBase>) register.invoke(registrywritable, newKey, biome, regInfo);
 
-        // Holder.Reference.bindValue
-        Method bindValue = Holder.c.class.getDeclaredMethod("b", Object.class);
-        bindValue.setAccessible(true);
-        bindValue.invoke(holder, biome);
+        Object registrationInfo = getDefaultRegistrationInfo();
+        if (!(registrationInfo instanceof net.minecraft.core.RegistrationInfo)) {
+            throw new IllegalStateException("Expected RegistrationInfo but got " + registrationInfo.getClass().getName());
+        }
 
-        // what the fuck is happening here 23/4/2024
+        // Capture the raw returned object
+        Object rawHolder = register.invoke(
+                registrywritable,
+                newKey,
+                biome, registrationInfo
+        );
 
-        // Make unregisteredIntrusiveHolders null again to remove potential for undefined behaviour
-        // unregisteredIntrusiveHolders.set(registrywritable, null);
+        // Safely cast if it's indeed of the expected type
+        if (rawHolder instanceof Holder.c) {
+            Holder.c<BiomeBase> holder = (Holder.c<BiomeBase>) rawHolder;
 
-        // There is a slightly cleaner way this can be done (void bindValue(T value)
-        // instead of the whole unregistered intrusive holders stuff),
-        // but it also involves reflection so I don't want to
-        // change this out just yet. Consider for the next version.
-        terraformGenBiomeRegistry.put(biomeType, newKey);
+            // Proceed with binding and registering the value
+            Method bindValue = Holder.c.class.getDeclaredMethod("b", Object.class);
+            bindValue.setAccessible(true);
+            bindValue.invoke(holder, biome);
 
+            terraformGenBiomeRegistry.put(biomeType, newKey);
+        } else {
+            throw new IllegalStateException("Unexpected return type: " + rawHolder.getClass().getName());
+        }
     }
 
+    private static BiomeSettingsMobs getBiomeSettingsMobs(BiomeBase forestbiome) throws NoSuchFieldException, IllegalAccessException {
+        Field biomeSettingMobsField = BiomeBase.class.getDeclaredField("k");
+        biomeSettingMobsField.setAccessible(true);
+        return (BiomeSettingsMobs) biomeSettingMobsField.get(forestbiome);
+    }
+
+    private static BiomeSettingsGeneration getBiomeSettingsGeneration(BiomeBase forestbiome) throws NoSuchFieldException, IllegalAccessException {
+        Field biomeSettingGenField = BiomeBase.class.getDeclaredField("j");
+        biomeSettingGenField.setAccessible(true);
+        return (BiomeSettingsGeneration) biomeSettingGenField.get(forestbiome);
+    }
+
+    private static void setBiomeColors(BiomeFog.a newFog, CustomBiomeType biomeType, BiomeBase forestbiome) {
+        newFog.a(biomeType.getFogColor().isEmpty() ? forestbiome.e() : Integer.parseInt(biomeType.getFogColor(), 16));
+        newFog.b(biomeType.getWaterColor().isEmpty() ? forestbiome.i() : Integer.parseInt(biomeType.getWaterColor(), 16));
+        newFog.c(biomeType.getWaterFogColor().isEmpty() ? forestbiome.j() : Integer.parseInt(biomeType.getWaterFogColor(), 16));
+        newFog.d(biomeType.getSkyColor().isEmpty() ? forestbiome.a() : Integer.parseInt(biomeType.getSkyColor(), 16));
+        newFog.e(biomeType.getFoliageColor().isEmpty() ? forestbiome.f() : Integer.parseInt(biomeType.getFoliageColor(), 16));
+        newFog.f(biomeType.getGrassColor().isEmpty() ? Integer.parseInt("79C05A", 16) : Integer.parseInt(biomeType.getGrassColor(), 16));
+    }
+
+    private static Object getDefaultRegistrationInfo() throws NoSuchFieldException, IllegalAccessException {
+        Field defaultRegInfoField = ReloadableServerRegistries.class.getDeclaredField("c");
+        defaultRegInfoField.setAccessible(true);
+        return defaultRegInfoField.get(null);
+    }
 
     public static Set<Holder<BiomeBase>> biomeListToBiomeBaseSet(@NotNull IRegistry<BiomeBase> registry) {
-
         List<Holder<BiomeBase>> biomeBases = new ArrayList<>();
 
         for (Biome biome : Biome.values()) {
@@ -241,10 +185,8 @@ public class CustomBiomeHandler {
                 continue;
             }
             try {
-                // Preconditions.checkArgument(biome != Biome.CUSTOM, "Cannot use the biome %s", biome);
                 biomeBases.add(CraftBiome.bukkitToMinecraftHolder(biome));
-            }
-            catch (IllegalStateException e) {
+            } catch (IllegalStateException e) {
                 TerraformGeneratorPlugin.logger.info("Ignoring biome " + biome);
             }
         }
@@ -254,8 +196,6 @@ public class CustomBiomeHandler {
                 continue;
             }
             ResourceKey<BiomeBase> rkey = CustomBiomeHandler.terraformGenBiomeRegistry.get(cbt);
-            // TerraformGeneratorPlugin.logger.info(cbt + " --- " + rkey);
-            // Holder.c is Holder.Reference. It implements Holder. No idk why.
             Optional<Holder.c<BiomeBase>> holder = registry.b(rkey);
             holder.ifPresent(biomeBases::add);
         }


### PR DESCRIPTION
…ecraft 1.21.1

- Adjusted reflection logic to properly handle and inspect return types during biome registration.
- Implemented runtime type inspection to ensure correct casting to Holder.c<BiomeBase>.
- Resolved casting errors related to biome registration under the "mysticbiomes" namespace.
- Improved error handling and logging for better diagnosis of unexpected types during biome registry operations.

This fix addresses an issue where incorrect type casting caused crashes when registering custom biomes.