### PR TITLE
Fix wrong numbers on float-conversion

### DIFF
--- a/buildProj/build.gradle.kts
+++ b/buildProj/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     implementation(project(":implementation:v1_20_R4"))
     implementation(project(":implementation:v1_21_R1"))
     implementation(project(":implementation:v1_21_R2"))
-    implementation("com.github.AvarionMC:yaml:1.1.3")
+    implementation("com.github.AvarionMC:yaml:1.1.5")
 }
 
 tasks.shadowJar {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -4,7 +4,7 @@ dependencies {
     compileOnly(group = "org.spigotmc", name = "spigot", version = "1.18-R0.1-SNAPSHOT")
 	// compileOnly(group = "org.spigotmc", name = "spigot", version = "1.16.4-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
-    compileOnly("com.github.AvarionMC:yaml:1.1.3")
+    compileOnly("com.github.AvarionMC:yaml:1.1.5")
 }
 
 // Set this to the lowest compat in implementation

--- a/common/src/main/java/org/terraform/main/config/TConfig.java
+++ b/common/src/main/java/org/terraform/main/config/TConfig.java
@@ -1,5 +1,6 @@
 package org.terraform.main.config;
 
+import org.avarion.yaml.Leniency;
 import org.avarion.yaml.YamlComment;
 import org.avarion.yaml.YamlFile;
 import org.avarion.yaml.YamlFileInterface;

--- a/common/src/main/java/org/terraform/main/config/TConfig.java
+++ b/common/src/main/java/org/terraform/main/config/TConfig.java
@@ -7,6 +7,7 @@ import org.avarion.yaml.YamlKey;
 import java.io.File;
 import java.io.IOException;
 
+@YamlFile(lenient = Leniency.LENIENT)
 public class TConfig extends YamlFileInterface {
     public static TConfig c;
     public static void init(final File f) throws IOException {

--- a/common/src/main/java/org/terraform/main/config/TConfig.java
+++ b/common/src/main/java/org/terraform/main/config/TConfig.java
@@ -8,6 +8,7 @@ import org.avarion.yaml.YamlKey;
 import java.io.File;
 import java.io.IOException;
 
+
 @YamlFile(lenient = Leniency.LENIENT)
 public class TConfig extends YamlFileInterface {
     public static TConfig c;

--- a/common/src/main/java/org/terraform/main/config/TConfig.java
+++ b/common/src/main/java/org/terraform/main/config/TConfig.java
@@ -1,6 +1,7 @@
 package org.terraform.main.config;
 
 import org.avarion.yaml.YamlComment;
+import org.avarion.yaml.YamlFile;
 import org.avarion.yaml.YamlFileInterface;
 import org.avarion.yaml.YamlKey;
 

--- a/implementation/v1_18_R2/build.gradle.kts
+++ b/implementation/v1_18_R2/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     implementation(project(":common"))
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.18.2-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
-    compileOnly("com.github.AvarionMC:yaml:1.1.3")
+    compileOnly("com.github.AvarionMC:yaml:1.1.5")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/implementation/v1_19_R3/build.gradle.kts
+++ b/implementation/v1_19_R3/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     implementation(project(":common"))
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.19.4-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
-    compileOnly("com.github.AvarionMC:yaml:1.1.3")
+    compileOnly("com.github.AvarionMC:yaml:1.1.5")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/implementation/v1_20_R1/build.gradle.kts
+++ b/implementation/v1_20_R1/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     implementation(project(":common"))
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.20.1-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
-    compileOnly("com.github.AvarionMC:yaml:1.1.3")
+    compileOnly("com.github.AvarionMC:yaml:1.1.5")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/implementation/v1_20_R2/build.gradle.kts
+++ b/implementation/v1_20_R2/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     implementation(project(":common"))
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.20.2-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
-    compileOnly("com.github.AvarionMC:yaml:1.1.3")
+    compileOnly("com.github.AvarionMC:yaml:1.1.5")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/implementation/v1_20_R3/build.gradle.kts
+++ b/implementation/v1_20_R3/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     implementation(project(":common"))
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.20.3-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
-    compileOnly("com.github.AvarionMC:yaml:1.1.3")
+    compileOnly("com.github.AvarionMC:yaml:1.1.5")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/implementation/v1_20_R4/build.gradle.kts
+++ b/implementation/v1_20_R4/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     implementation(project(":common"))
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.20.5-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
-    compileOnly("com.github.AvarionMC:yaml:1.1.3")
+    compileOnly("com.github.AvarionMC:yaml:1.1.5")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/implementation/v1_21_R1/build.gradle.kts
+++ b/implementation/v1_21_R1/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     implementation(project(":common"))
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.21.1-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
-    compileOnly("com.github.AvarionMC:yaml:1.1.3")
+    compileOnly("com.github.AvarionMC:yaml:1.1.5")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_21

--- a/implementation/v1_21_R2/build.gradle.kts
+++ b/implementation/v1_21_R2/build.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     implementation(project(":common"))
 	compileOnly(group = "org.spigotmc", name = "spigot", version = "1.21.3-R0.1-SNAPSHOT")
     compileOnly("org.jetbrains:annotations:20.1.0")
-    compileOnly("com.github.AvarionMC:yaml:1.1.3")
+    compileOnly("com.github.AvarionMC:yaml:1.1.5")
 }
 java {
     sourceCompatibility = JavaVersion.VERSION_21


### PR DESCRIPTION
0.51 cannot be represented as a float. It's actually 0.5099999904632568.

But if you don't really care about it, we can use the newly introduced "leniency" parameter for the configuration.