### PR TITLE
Update CompressedChunkBools.java

### DIFF
--- a/common/src/main/java/org/terraform/coregen/populatordata/PopulatorDataSpigotAPI.java
+++ b/common/src/main/java/org/terraform/coregen/populatordata/PopulatorDataSpigotAPI.java
@@ -193,7 +193,11 @@ public class PopulatorDataSpigotAPI extends PopulatorDataAbstract
 
     @Override
     public void spawnMinecartWithChest(int x, int y, int z, @NotNull TerraLootTable table, Random random) {
-
+        if (!lr.isInRegion(x, y, z)) {
+            TerraformGeneratorPlugin.logger.error("Tried to spawn minecart outside of LR bounds at: "+x + "," + y + "," + z + " from LR centered at chunk " + chunkX + "," + chunkZ);
+            return;
+        }
+        
         StorageMinecart e = (StorageMinecart) lr.spawnEntity(
                 new Location(tw.getWorld(), x + 0.5f, y + 0.5f, z + 0.5f),
                 EntityType.MINECART_CHEST

--- a/common/src/main/java/org/terraform/utils/datastructs/CompressedChunkBools.java
+++ b/common/src/main/java/org/terraform/utils/datastructs/CompressedChunkBools.java
@@ -13,14 +13,26 @@ public class CompressedChunkBools {
 
     public void set(int x, int y, int z){
         int idY = y-TerraformGeneratorPlugin.injector.getMinY();
+        if (idY < 0 || idY >= matrix.length || x < 0 || x >= 16 || z < 0 || z >= 16) {
+            return;
+        }
         matrix[idY][x] = (short) (matrix[idY][x] | (0b1 << z));
     }
     public void unSet(int x, int y, int z){
         int idY = y-TerraformGeneratorPlugin.injector.getMinY();
+        if (idY < 0 || idY >= matrix.length || x < 0 || x >= 16 || z < 0 || z >= 16) {
+            return;
+        }
         matrix[idY][x] = (short) (matrix[idY][x] & (255 ^ (0b1 << z)));
     }
 
     public boolean isSet(int x, int y, int z){
         return (matrix[y-TerraformGeneratorPlugin.injector.getMinY()][x] & (0b1 << z)) > 0;
+        int idY = y-TerraformGeneratorPlugin.injector.getMinY();
+        if (idY < 0 || idY >= matrix.length || x < 0 || x >= 16 || z < 0 || z >= 16) {
+            return false;
+        }
+        return (matrix[idY][x] & (0b1 << z)) > 0;
     }
 }
+

--- a/implementation/v1_21_R5/src/main/java/org/terraform/v1_21_R5/NMSChunkGenerator.java
+++ b/implementation/v1_21_R5/src/main/java/org/terraform/v1_21_R5/NMSChunkGenerator.java
@@ -396,6 +396,11 @@ public class NMSChunkGenerator extends ChunkGenerator {
         SingleMegaChunkStructurePopulator[] spops = StructureRegistry.getLargeStructureForMegaChunk(tw, mc);
         int[] centerCoords = mc.getCenterBiomeSectionChunkCoords();
 
+        if (spops == null) {
+            TerraformGeneratorPlugin.logger.info(chunkcoordintpair.h + "," + chunkcoordintpair.i + " No structures found for this mega chunk");
+            return;
+        }
+
         for(SingleMegaChunkStructurePopulator pop:spops)
         {
             if(!(pop instanceof VanillaStructurePopulator vpop)) continue;


### PR DESCRIPTION
Fixing an ArrayIndexOutOfBoundsException I encountered(https://termbin.com/azih), silently ignoring out-of-bounds values. (Probably not a good implementation, idk how it fucks with my world-gen, but better than the server crashing ig) hope it helps with at least pinpointing the issue

If its complete BS, I wouldn't mind this PR getting dropped too
Thanks for this wonderful plugin :3