### PR TITLE
fix: Fix double chests in catacomb caskets having a broken state

### DIFF
--- a/common/src/main/java/org/terraform/structure/catacombs/CatacombsCasketRoomPopulator.java
+++ b/common/src/main/java/org/terraform/structure/catacombs/CatacombsCasketRoomPopulator.java
@@ -65,8 +65,7 @@ public class CatacombsCasketRoomPopulator extends CatacombsStandardPopulator {
                 if (TConfig.areDecorationsEnabled()) {
                     new ChestBuilder(Material.CHEST).setFacing(BlockUtils.getLeft(target.getDirection()))
                                                     .setLootTable(TerraLootTable.SIMPLE_DUNGEON)
-                                                    .apply(target)
-                                                    .extend(target, target.getFront(), false);
+                                                    .extend(target, target.getFront(), true);
                 }
                 break;
             case 1:


### PR DESCRIPTION
Quick fix to the double chests in caskets in the catacombs.

I assume the problem was that both `apply()` and `extend()` were setting the original block (left chest), where the second update was dropped.

Before: (The right chest would be empty)
<img width="332" height="256" alt="2025-11-16_03 08 32" src="https://github.com/user-attachments/assets/50003aeb-0265-4476-8e79-634afdcd47c5" />
After: (Both are filled)
<img width="332" height="256" alt="2025-11-16_03 08 38" src="https://github.com/user-attachments/assets/6e9f8e76-cefa-4e28-af59-8a38307f735e" />
