### PR TITLE
Fix OutOfBounds exception in Dungeon Populators (Y-level constraints)

### DIFF
--- a/common/src/main/java/org/terraform/structure/small/dungeon/DrownedDungeonPopulator.java
+++ b/common/src/main/java/org/terraform/structure/small/dungeon/DrownedDungeonPopulator.java
@@ -52,7 +52,6 @@ public class DrownedDungeonPopulator extends SmallDungeonPopulator {
 
         // int y = GenUtils.getHighestGround(data, x, z);
 
-
         spawnDungeonRoom(x, z, tw, rand, data);
     }
 
@@ -63,6 +62,7 @@ public class DrownedDungeonPopulator extends SmallDungeonPopulator {
                                  @NotNull PopulatorDataAbstract data)
     {
         TerraformGeneratorPlugin.logger.info("Spawning Drowned Dungeon at " + x + "," + z);
+
         int setIndex = rand.nextInt(sets.length);
         Material[] set = sets[setIndex];
         int radius = GenUtils.randInt(rand, 5, 10);
@@ -76,9 +76,19 @@ public class DrownedDungeonPopulator extends SmallDungeonPopulator {
 
                 int y = HeightMap.getBlockHeight(tw, x, z);// GenUtils.getHighestGround(data, nx + x, nz + z);
 
+                // Skip positions too close to world height bounds to avoid invalid block placement
+                if (y >= tw.maxY - 10 || y < tw.minY) {
+                    continue;
+                }
+
                 // Spawner
                 if (nx == 0 && nz == 0) {
-                    data.setSpawner(x, y + 1, z, EntityType.DROWNED);
+                    int spawnerY = y + 1;
+                    if (spawnerY >= tw.minY && spawnerY < tw.maxY) {
+                        data.setSpawner(x, spawnerY, z, EntityType.DROWNED);
+                    } else {
+                        TerraformGeneratorPlugin.logger.info("Drowned Dungeon spawner at " + x + "," + spawnerY + "," + z + " skipped (out of bounds)");
+                    }
                     continue;
                 }
 

--- a/common/src/main/java/org/terraform/structure/small/dungeon/UndergroundDungeonPopulator.java
+++ b/common/src/main/java/org/terraform/structure/small/dungeon/UndergroundDungeonPopulator.java
@@ -58,19 +58,22 @@ public class UndergroundDungeonPopulator extends SmallDungeonPopulator {
 
         int x = spawnCoords[0];// data.getChunkX()*16 + random.nextInt(16);
         int z = spawnCoords[1];// data.getChunkZ()*16 + random.nextInt(16);
+
         Random rand = this.getHashedRandom(tw, data.getChunkX(), data.getChunkZ());
 
-        int y = HeightMap.getBlockHeight(tw, x, z) - GenUtils.randInt(
-                rand,
-                15,
-                50
-        );// GenUtils.getHighestGround(data, x, z)
+        // Cap the base height to prevent the dungeon from generating out the world height limit.
+        // 20-block buffer for the dungeon height/decorations.
+        int baseHeight = Math.min(HeightMap.getBlockHeight(tw, x, z), tw.maxY - 20);
+        int y = baseHeight - GenUtils.randInt(rand, 15, 50);
 
-        if (y < 10) {
-            y = 10;
+        // Support 1.18+ negative coordinates.
+        int safeMinY = tw.minY + 10;
+        if (y < safeMinY) {
+            y = safeMinY;
         }
 
-        while (!data.getType(x, y, z).isSolid()) {
+        // Ensure we don't decrement y below the world's minimum height
+        while (y > tw.minY && !data.getType(x, y, z).isSolid()) {
             y--;
         }
 
@@ -204,7 +207,13 @@ public class UndergroundDungeonPopulator extends SmallDungeonPopulator {
             type = EntityType.DROWNED;
         }
 
-        data.setSpawner(x, y + 1, z, type);
+        // Safe check max or min height for place
+        int spawnerY = y + 1;
+        if (spawnerY >= tw.minY && spawnerY < tw.maxY) {
+            data.setSpawner(x, spawnerY, z, type);
+        } else {
+            TerraformGeneratorPlugin.logger.info("Underground Dungeon spawner at " + x + "," + spawnerY + "," + z + " skipped (out of bounds)");
+        }
 
         // Spawn chests
         ArrayList<Entry<Wall, Integer>> entries = new ArrayList<>();


### PR DESCRIPTION
Hey, I encountered a issue while pre-generating a world using **Chunky** on **1.21.11** (_leaf_) with the latest version of **TerraformGenerator**. During the chunk generation process, the server repeatedly crashed due to an **attempt to place a spawner above the allowable world height limits**.

Initially, I tried change configurations and reverting to default settings, but the crashes persisted over time. Consequently, I decided to investigate the source code to implement a fix that would allow the world to generate safely. Alongside the spawner checks, I also added general height checks for placing these small structures, as they were the root cause of the problem.

Here is an example of the stack trace I encountered:

<details>
<summary>Click to expand the crash log</summary>

> [16:41:49] [Server thread/INFO]: [Chunky] Task running for world_res. Processed: 132692 chunks (8.48%), ETA: 1:04:24, Rate: 370.7 cps, Current: 210, -72
> [16:41:51] [Paper Common Worker #0/ERROR]: [ChunkTaskScheduler] Chunk system error at chunk (195,-123), holder: ...
> java.lang.Throwable: java.lang.IllegalArgumentException: Coordinates 3129, 320, -1965 are not in the region
> 	at ca.spottedleaf.moonrise.patches.chunk_system.scheduling.ChunkTaskScheduler.unrecoverableChunkSystemFailure(ChunkTaskScheduler.java:304) ~[leaf-1.21.11.jar:1.21.11-63-00733fc]
> ...
> Caused by: java.lang.IllegalArgumentException: Coordinates 3129, 320, -1965 are not in the region
> 	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:463) ~[guava-33.5.0-jre.jar:?]
> 	at org.bukkit.craftbukkit.generator.CraftLimitedRegion.getBlockState(CraftLimitedRegion.java:192) ~[leaf-1.21.11.jar:1.21.11-63-00733fc]
> 	at TerraformGenerator-25.0.2.jar//org.terraform.coregen.populatordata.PopulatorDataSpigotAPI.setSpawner(PopulatorDataSpigotAPI.java:124) ~[?:?]
> 	at TerraformGenerator-25.0.2.jar//org.terraform.structure.small.dungeon.UndergroundDungeonPopulator.spawnDungeonRoom(UndergroundDungeonPopulator.java:207) ~[?:?]
</details>

To ensure safe generation and prevent server crashes, I've added minimal height checks when placing these structures:

**Changes made**
- **UndergroundDungeonPopulator:** Added constraints to `baseHeight` and a world bounds check inside the `while` loop to prevent it from decrementing `y` below `tw.minY` in deep ravines/caves. Also added `spawnerY` bounds check.
- **DrownedDungeonPopulator:** Added height checks (`y >= tw.maxY - 10 || y < tw.minY`) to prevent structures and spawners from being placed outside safe limits.