### PR TITLE
Fix server crash during generation on Peaceful difficulty

### DIFF
--- a/common/src/main/java/org/terraform/coregen/populatordata/PopulatorDataAbstract.java
+++ b/common/src/main/java/org/terraform/coregen/populatordata/PopulatorDataAbstract.java
@@ -1,9 +1,11 @@
 package org.terraform.coregen.populatordata;
 
+import org.bukkit.Difficulty;
 import org.bukkit.Material;
 import org.bukkit.block.Biome;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Monster;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -101,6 +103,17 @@ public abstract class PopulatorDataAbstract {
     public abstract @Nullable Biome getBiome(int rawX, int rawZ);
 
     public abstract void addEntity(int rawX, int rawY, int rawZ, EntityType type);
+
+    /**
+     * Returns true if the given EntityType is a hostile monster that must not be
+     * spawned in Peaceful difficulty. Uses Bukkit's Monster interface, which covers
+     * Witch, Skeleton, Husk, Drowned, Guardian, Elder Guardian, Cave Spider,
+     * Spider, Silverfish, Vindicator, Evoker, Pillager, and all other hostiles.
+     */
+    public static boolean isHostileMob(@NotNull EntityType type) {
+        Class<?> cls = type.getEntityClass();
+        return cls != null && Monster.class.isAssignableFrom(cls);
+    }
 
     public abstract int getChunkX();
 

--- a/common/src/main/java/org/terraform/coregen/populatordata/PopulatorDataPostGen.java
+++ b/common/src/main/java/org/terraform/coregen/populatordata/PopulatorDataPostGen.java
@@ -1,6 +1,7 @@
 package org.terraform.coregen.populatordata;
 
 import org.bukkit.*;
+import org.bukkit.Difficulty;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
@@ -122,6 +123,9 @@ public class PopulatorDataPostGen extends PopulatorDataICABiomeWriterAbstract im
 
     @Override
     public void addEntity(int x, int y, int z, @NotNull EntityType type) {
+        if (w.getDifficulty() == Difficulty.PEACEFUL && isHostileMob(type)) {
+            return; // Do not spawn hostile mobs on peaceful servers
+        }
         // Always offset by 0.5 to prevent them spawning in corners.
         // Y is offset by a small bit to prevent falling through weird spawning areas
         Entity e = c.getWorld().spawnEntity(new Location(c.getWorld(), x + 0.5, y + 0.3, z + 0.5), type);

--- a/common/src/main/java/org/terraform/coregen/populatordata/PopulatorDataSpigotAPI.java
+++ b/common/src/main/java/org/terraform/coregen/populatordata/PopulatorDataSpigotAPI.java
@@ -1,6 +1,7 @@
 package org.terraform.coregen.populatordata;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Difficulty;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.RegionAccessor;
@@ -92,6 +93,9 @@ public class PopulatorDataSpigotAPI extends PopulatorDataAbstract
         if (!lr.isInRegion(rawX, rawY, rawZ)) {
             TerraformGeneratorPlugin.logger.error("Tried to add entity outside of LR bounds at: "+rawX + "," + rawZ + " from LR centered at chunk " + chunkX + "," + chunkZ);
             return;
+        }
+        if (tw.getWorld().getDifficulty() == Difficulty.PEACEFUL && isHostileMob(type)) {
+            return; // Do not spawn hostile mobs on peaceful servers
         }
         lr.spawnEntity(new Location(tw.getWorld(), rawX, rawY, rawZ), type);
     }

--- a/common/src/main/java/org/terraform/structure/catacombs/CatacombsStandardPopulator.java
+++ b/common/src/main/java/org/terraform/structure/catacombs/CatacombsStandardPopulator.java
@@ -1,5 +1,6 @@
 package org.terraform.structure.catacombs;
 
+import org.bukkit.Difficulty;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.data.Bisected.Half;
@@ -130,7 +131,8 @@ public class CatacombsStandardPopulator extends RoomPopulatorAbstract {
             SimpleBlock target = new SimpleBlock(data, coords[0], room.getY() + 1, coords[2]);
             target = target.getAtY(room.getY() + 1);
 
-            if (data instanceof PopulatorDataSpigotAPI) {
+            if (data instanceof PopulatorDataSpigotAPI
+                && data.getTerraformWorld().getWorld().getDifficulty() != Difficulty.PEACEFUL) {
                 Skeleton e = (Skeleton) ((PopulatorDataSpigotAPI) data).lr
                         .spawnEntity(new Location(
                                         Objects.requireNonNull(data.getTerraformWorld()).getWorld(),


### PR DESCRIPTION
### Root Cause
The server crash occurs on `Peaceful` difficulty because the chunk generator attempts to spawn hostile mobs (like Witches in Swamp Huts). On Paper/Purpur servers, calling `spawnEntity` for a monster in a peaceful world throws an `IllegalStateException`, which crashes the server during world generation.

### How this fixes the bug
There are over 17 distinct locations where hostile mobs are spawned, but they all funnel through two structural paths: `PopulatorDataSpigotAPI.addEntity()` (for chunk generation) and `PopulatorDataPostGen.addEntity()` (for post-generation). 

Instead of adding difficulty checks to every individual structure, this patch implements a centralized guard:
1. **Helper Method**: Added `isHostileMob(EntityType)` to `PopulatorDataAbstract`, which dynamically checks if the entity implements Bukkit's `org.bukkit.entity.Monster` interface. This cleanly covers Witches, Skeletons, Guardians, Pillagers, and any future hostile mobs.
2. **Guarded Spawns**: Added a check at the top of the `addEntity` methods in `PopulatorDataSpigotAPI` and `PopulatorDataPostGen`. If the world is set to Peaceful and the entity is a hostile monster, the spawn is silently aborted.
3. **Catacombs Bypass**: `CatacombsStandardPopulator` was the only class that bypassed `addEntity()` to call `spawnEntity` directly (to equip a sword). We added a specific guard for this edge case.